### PR TITLE
Tool: update some test deps

### DIFF
--- a/tool/deps.edn
+++ b/tool/deps.edn
@@ -18,12 +18,12 @@
 
            :test      {:extra-paths ["test" "src/test_utils"]
                        :extra-deps  {org.clojure/test.check     {:mvn/version "0.10.0-alpha3"}
-                                     eftest                     {:mvn/version "0.5.2"}}}
+                                     eftest                     {:mvn/version "0.5.3"}}}
 
            :test/run  {:main-opts   ["-m" "fc4.test-runner.runner"]}
 
            :test/coverage
-                      {:extra-deps  {cloverage                  {:mvn/version "1.0.11"}}
+                      {:extra-deps  {cloverage                  {:mvn/version "1.0.13"}}
                        :main-opts   ["-m" "cloverage.coverage"
                                      "--src-ns-path" "src/main"
                                      "--test-ns-path" "test"

--- a/tool/src/test_utils/fc4/test_runner/runner.clj
+++ b/tool/src/test_utils/fc4/test_runner/runner.clj
@@ -33,11 +33,10 @@
   (let [report-to-file-fn (report-to-file ju/report output-path)
         report-fn (multi-report progress/report report-to-file-fn)]
     {:report report-fn
-     ;; Specifying a constraint on the multithreading behavior because without
-     ;; this the XML output of the JUnit reporter is malformed, as per this bug:
-     ;; https://github.com/weavejester/eftest/issues/47
-     ;; I tested the other supported value (:namespaces) and it was
-     ;; significantly slower.
+     ;; :multithread? supports a few different values; I tested the other
+     ;; supported values (:namespaces and `true`) and they were both
+     ;; significantly slower. For more see
+     ;; https://github.com/weavejester/eftest/#multithreading
      :multithread? :vars}))
 
 (defn run-tests


### PR DESCRIPTION
I had been hoping to be able to remove the `:multithreading?` option from the eftest config, in the hopes that the default would be simpler, faster, and have lower maintenance implications (cognitive load).

I had thought this might be possible because the latest version of Eftest includes [this fix](https://github.com/weavejester/eftest/pull/58) by @nachomdo.

Unfortunately when I tested the other possible values for `:multithreading?` — including `true` which is the default — the tests took significantly longer to run (on my laptop). I’m not sure why, but regardless, that’s no good.

Given these results, this change ~doesn’t seem to yield any compelling concrete benefits right now~ (update: see below); rather by updating the comment to remove the reference to the bug that Nacho fixed, hopefully this will obviate the need for someone else to think about this in the future. i.e. potentially slightly lower future maintenance costs.

In addition I think it’s just a generally and broadly beneficial practice to keep dependencies up to date when practical. So there’s that at least.

#### Update

The above is just the commit message from the one commit in this branch. I also have another branch, one based on this one, in which I’d been seeing mysterious test failures. Once I added this commit to that branch (via rebase) the mysterious test failures seem to have disappeared. So that would seem to be a concrete benefit, to me.