### PR TITLE
Add link to the "fc4-tool" on the "Toolset" page

### DIFF
--- a/methodology/toolset.md
+++ b/methodology/toolset.md
@@ -6,11 +6,11 @@ The current toolset for authoring and editing FC4 diagrams is:
 | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | Any text editor                                              | Creating the diagram files; authoring/editing the semantic contents of the diagrams: the elements, relationships, etc |
 | [Structurizr Express](https://structurizr.com/help/express)  | Graphical authoring/editing the positioning of the elements; rendering the diagrams |
-| fc4-tool | Reformatting and normalizing the source of the diagrams so they’re diffable and easier to edit; snapping elements to a virtual grid |
+| [fc4-tool][fc4-tool] | Reformatting and normalizing the source of the diagrams so they’re diffable and easier to edit; snapping elements to a virtual grid |
 
 ## fc4-tool
 
-fc4-tool was created because when one uses Structurizr Express (SE) to position the elements of a diagram, SE regenerates the diagram source YAML in such a way that the YAML becomes noisy and the sorting can change. This makes the source harder to work with in a text editor and impossible to usefully diff from revision to revision — and without useful diffing it’s very difficult to do effective peer review.
+[fc4-tool][fc4-tool] was created because when one uses Structurizr Express (SE) to position the elements of a diagram, SE regenerates the diagram source YAML in such a way that the YAML becomes noisy and the sorting can change. This makes the source harder to work with in a text editor and impossible to usefully diff from revision to revision — and without useful diffing it’s very difficult to do effective peer review.
 
 So fc4-tool processes the YAML: cleans it up, applies a stable sort to all properties, removes empty properties, etc — so as to ensure that the changes applied in each revision are very small and specific and all extraneous changes are filtered out. This will hopefully enable effective peer review of revisions to the diagrams.
 
@@ -21,3 +21,5 @@ The functionality of fc4-tool may expand over time to include additional feature
 ----
 
 Please continue to [The Repository](repository.md) or go back to [the top page](README.md).
+
+[fc4-tool]: https://github.com/FundingCircle/fc4-framework/tree/master/tool


### PR DESCRIPTION
We have a [direct link](https://github.com/ministryofjustice/laa-architecture-documentation/blob/356c2923f8db2c195487388ff4a54e8e3517efc2/README.md#legal-aid-agency-architecture-documentation) to the https://fundingcircle.github.io/fc4-framework/methodology/toolset.html
page.

New users learn about the "fc4-tool" but cannot see what it is unless they navigate away from the page.

This change adds a link to the directory containing the tool in GitHub to make resolving "fc4-tool" less of a quest for people who are unfamiliar with the framework.