### PR TITLE
Fix an intermittently failing test

### DIFF
--- a/tool/test/fc4/integrations/structurizr/express/clipboard_test.clj
+++ b/tool/test/fc4/integrations/structurizr/express/clipboard_test.clj
@@ -42,6 +42,5 @@
     (testing "processing a file that’s valid and has been cleaned"
       (let [fp  "test/data/structurizr/express/diagram_valid_cleaned.yaml"
             in  (slurp fp)
-            out (binding [*out* (java.io.StringWriter.)]
-                  (c/try-process in))]
+            out (c/try-process in)]
         (is (= in out))))))


### PR DESCRIPTION
I don’t know why this test failed intermittently, but in looking the
test and its subject over to try to figure it out, I noticed that the
function both returned a value *and* wrote it to stdout as a side effect
which seemed very fuzzy to me, and it looked like this had led to the
test being muddled over what it should be testing — the return value or
the side effect. So I fixed the function by removing the main side
effect and moving it to the function that _calls_ this function.