### PR TITLE
Node Renderer

### DIFF
--- a/tool/renderer/.gitignore
+++ b/tool/renderer/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tool/renderer/package-lock.json
+++ b/tool/renderer/package-lock.json
@@ -85,7 +85,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"

--- a/tool/renderer/package-lock.json
+++ b/tool/renderer/package-lock.json
@@ -1,0 +1,320 @@
+{
+  "name": "fc4-se-renderer",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/node": {
+      "version": "8.10.36",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.36.tgz",
+      "integrity": "sha512-SL6KhfM7PTqiFmbCW3eVNwVBZ+88Mrzbuvn9olPsfv43mbiWaFY+nRcz/TGGku0/lc2FepdMbImdMY1JrQ+zbw=="
+    },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
+      }
+    },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "data-uri-to-buffer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.0.tgz",
+      "integrity": "sha512-YbKCNLPPP4inc0E5If4OaalBc7gpaM2MRv77Pv2VThVComLKfbGYtJcdDCViDyp1Wd4SebhHLz94vp91zbK6bw==",
+      "requires": {
+        "@types/node": "^8.0.7"
+      }
+    },
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "extract-zip": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "fd-slicer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "requires": {
+        "pend": "~1.2.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "mime": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "progress": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
+      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg=="
+    },
+    "proxy-from-env": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+      "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
+    },
+    "puppeteer": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.9.0.tgz",
+      "integrity": "sha512-GH4PmhJf9wBRAPvtJkEJLAvdNNOofZortmBZSj8cGWYni98GUFqsf66blOEfJbo5B8l0KG5HR2d/W2MejnUrzg==",
+      "requires": {
+        "debug": "^3.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
+        "mime": "^2.0.3",
+        "progress": "^2.0.0",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^5.1.1"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "^7.0.5"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "yauzl": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "requires": {
+        "fd-slicer": "~1.0.1"
+      }
+    }
+  }
+}

--- a/tool/renderer/package-lock.json
+++ b/tool/renderer/package-lock.json
@@ -85,7 +85,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "requires": {
         "es6-promise": "^4.0.3"
@@ -236,18 +236,18 @@
       "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
     },
     "puppeteer": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.9.0.tgz",
-      "integrity": "sha512-GH4PmhJf9wBRAPvtJkEJLAvdNNOofZortmBZSj8cGWYni98GUFqsf66blOEfJbo5B8l0KG5HR2d/W2MejnUrzg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.4.0.tgz",
+      "integrity": "sha512-WDnC1FSHTedvRSS8BZB73tPAx2svUCWFdcxVjrybw8pbKOAB1v5S/pW0EamkqQoL1mXiBc+v8lyYjhhzMHIk1Q==",
       "requires": {
         "debug": "^3.1.0",
-        "extract-zip": "^1.6.6",
-        "https-proxy-agent": "^2.2.1",
+        "extract-zip": "^1.6.5",
+        "https-proxy-agent": "^2.1.0",
         "mime": "^2.0.3",
         "progress": "^2.0.0",
         "proxy-from-env": "^1.0.0",
         "rimraf": "^2.6.1",
-        "ws": "^5.1.1"
+        "ws": "^3.0.0"
       }
     },
     "readable-stream": {
@@ -290,6 +290,11 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -301,11 +306,13 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
       }
     },
     "yauzl": {

--- a/tool/renderer/package.json
+++ b/tool/renderer/package.json
@@ -5,12 +5,12 @@
   "main": "render.js",
   "dependencies": {
     "data-uri-to-buffer": "^2.0.0",
-    "puppeteer": "^1.9.0"
+    "puppeteer": "^1.4.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": "https://github.com/FundingCircle/fc4-framework.git",
   "author": "Avi Flax <avi.flax@fundingcircle.com>",
-  "license": "ISC"
+  "license": "BSD-3-Clause"
 }

--- a/tool/renderer/package.json
+++ b/tool/renderer/package.json
@@ -4,8 +4,8 @@
   "description": "Renders Structurizr Express diagrams in a headless browser using Puppeteer.",
   "main": "render.js",
   "dependencies": {
-    "puppeteer": "^1.9.0",
-    "data-uri-to-buffer": "^2.0.0"
+    "data-uri-to-buffer": "^2.0.0",
+    "puppeteer": "^1.9.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/tool/renderer/package.json
+++ b/tool/renderer/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "fc4-se-renderer",
+  "version": "1.0.0",
+  "description": "Renders Structurizr Express diagrams in a headless browser using Puppeteer.",
+  "main": "render.js",
+  "dependencies": {
+    "puppeteer": "^1.9.0",
+    "data-uri-to-buffer": "^2.0.0"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": "https://github.com/FundingCircle/fc4-framework.git",
+  "author": "Avi Flax <avi.flax@fundingcircle.com>",
+  "license": "ISC"
+}

--- a/tool/renderer/render.js
+++ b/tool/renderer/render.js
@@ -4,47 +4,93 @@ const dataUriToBuffer = require('data-uri-to-buffer');
 const {writeFileSync} = require('fs')
 const puppeteer = require('puppeteer');
 
-async function render(diagramYaml) {
-  const browser = await puppeteer.launch();
-  console.log('browser launched');
+function next(step) {
+  console.log(step + '...');
+}
 
+async function waitasec(page) {
+  next('pausing');
+  await page.waitFor(1000);
+}
+
+async function render(diagramYaml) {
+  console.log('launching browser...');
+  const browser = await puppeteer.launch({headless: true});
   const page = await browser.newPage();
 
+  async function asec() {
+    next('pausing');
+    await page.waitFor(1000);
+  }
+
+  next('loading SE');
   await page.goto('https://structurizr.com/express', {'waitUntil' : 'networkidle0'});
-  console.log('SE loaded');
 
-  await page.evaluate(()=> {
-      Structurizr.diagram.exportCurrentView(1, true, false, false, false);
-  });
+  await asec();
 
-  console.log('export function called');
+  next('setting YAML and updating diagram');
 
-  console.log('waiting 1 second...');
-  await page.waitFor(1000);
+  await page.evaluate(theYaml => {
+    function sleep(ms) {
+      return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    (async () => {
+      // helps with debugging, screenshots, etc
+      document.getElementById('expressIntroductionModal').style = "display: none;"
+    await sleep(200);
+      document.querySelector('a[href="#yaml"]').click();
+    await sleep(200);
+      const yamlTextArea = document.getElementById('yamlDefinition');
+    await sleep(200);
+      yamlTextArea.value = theYaml;
+    await sleep(200);
+      changes = true;
+    await sleep(200);
+      structurizrExpressToDiagram();
+    })();
+  }, diagramYaml);
+
+  await asec();
+  await page.evaluate(() => Structurizr.diagram.exportCurrentView(1, true, false, false, false));
+  await asec();
 
   const pages = await browser.pages()
   const exportPage = pages[2];
   const exportPageTitle = await exportPage.title()
   console.log('export page opened with title', exportPageTitle);
 
-  console.log('getting image...');
+  await waitasec(page);
+
+  next('getting image');
   const image = await exportPage.$('#exportedContent > img');
-  console.log('got image.');
+
+  await waitasec(page);
 
   console.log('getting image source...');
-  const imageSourceHandle = await image.evaluate('src');
+  const imageSourceHandle = await image.getProperty('src');
   const imageSource = await imageSourceHandle.jsonValue();
-  console.log('image source:', imageSource);
-
   const imageBuffer = dataUriToBuffer(imageSource);
 
-  console.log('got image source?', imageBuffer)
-
-  console.log('closing browser')
-  await browser.close();
+  console.log('closing browser...')
+await browser.close();
 
   return imageBuffer;
 }
 
-const ib = render(null);
-writeFileSync('/tmp/diagram.png', ib);
+async function main() {
+  const theYaml = `---
+elements:
+  -
+    type: 'Software System'
+    name: 'Fuck Off'
+    position: '300,300'
+type: 'System Context'
+scope: 'Fuck Off'
+size: A6_Landscape
+`
+  const ib = await render(theYaml);
+  writeFileSync('/tmp/diagram.png', ib);
+}
+
+main()

--- a/tool/renderer/render.js
+++ b/tool/renderer/render.js
@@ -95,7 +95,7 @@ async function render(diagramYaml, browser, url) {
   // doesn’t show up on the exported image. Which I think it should, because
   // Simon Brown wants it included in the images that Structurizr Express
   // exports, and it’s his software.
-  await abit(300);
+  await abit(350);
   await page.evaluate(() => Structurizr.diagram.exportCurrentView(1, true, false, false, false));
 
   log.next('getting export page');

--- a/tool/renderer/render.js
+++ b/tool/renderer/render.js
@@ -90,11 +90,21 @@ async function render(diagramYaml, browser, url) {
   }, diagramYaml);
 
   log.next('calling export function');
-  await abit(200);
+
+  // On my system, if this is any shorter than 300ms then the Structurizr logo
+  // doesn’t show up on the exported image. Which I think it should, because
+  // Simon Brown wants it included in the images that Structurizr Express
+  // exports, and it’s his software.
+  await abit(300);
   await page.evaluate(() => Structurizr.diagram.exportCurrentView(1, true, false, false, false));
 
-  log.next('getting export page')
-  await abit(250);
+  log.next('getting export page');
+
+  // I *think* I might have seem some intermittent race condition errors related
+  // to this pause; it seems pretty reliable on my system at 200ms, but we might
+  // need to bump this up a bit (e.g. 250ms) if we start seeing intermittent
+  // errors with the process.
+  await abit(200);
   const pages = await browser.pages();
   const exportPage = pages[2];
   exportPage.setOfflineMode(true);

--- a/tool/renderer/render.js
+++ b/tool/renderer/render.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+
+const dataUriToBuffer = require('data-uri-to-buffer');
+const {writeFileSync} = require('fs')
+const puppeteer = require('puppeteer');
+
+async function render(diagramYaml) {
+  const browser = await puppeteer.launch();
+  console.log('browser launched');
+
+  const page = await browser.newPage();
+
+  await page.goto('https://structurizr.com/express', {'waitUntil' : 'networkidle0'});
+  console.log('SE loaded');
+
+  await page.evaluate(()=> {
+      Structurizr.diagram.exportCurrentView(1, true, false, false, false);
+  });
+
+  console.log('export function called');
+
+  console.log('waiting 1 second...');
+  await page.waitFor(1000);
+
+  const pages = await browser.pages()
+  const exportPage = pages[2];
+  const exportPageTitle = await exportPage.title()
+  console.log('export page opened with title', exportPageTitle);
+
+  console.log('getting image...');
+  const image = await exportPage.$('#exportedContent > img');
+  console.log('got image.');
+
+  console.log('getting image source...');
+  const imageSourceHandle = await image.evaluate('src');
+  const imageSource = await imageSourceHandle.jsonValue();
+  console.log('image source:', imageSource);
+
+  const imageBuffer = dataUriToBuffer(imageSource);
+
+  console.log('got image source?', imageBuffer)
+
+  console.log('closing browser')
+  await browser.close();
+
+  return imageBuffer;
+}
+
+const ib = render(null);
+writeFileSync('/tmp/diagram.png', ib);

--- a/tool/renderer/render.js
+++ b/tool/renderer/render.js
@@ -5,23 +5,17 @@ const {existsSync} = require('fs');
 const path = require('path');
 const puppeteer = require('puppeteer');
 
-const log = {
+const log = function(msg) {
   // This program must log to stderr rather than stdout because it outputs its
   // result to stdout.
-  stderr(msg) {
-    // Calling process.stderr.write twice might be slightly more efficient than
-    // concatenating the newline to msg.
-    process.stderr.write(msg);
-    process.stderr.write('\n');
-  },
+  process.stderr.write(msg);
+  // Calling process.stderr.write twice might be slightly more efficient than
+  // concatenating the newline to msg.
+  process.stderr.write('\n');
+}
 
-  next(step) {
-    this.stderr(step + '...');
-  },
-
-  result(is) {
-    this.stderr(is + '.');
-  }
+log.next = function(step) {
+  this(step + '...');
 }
 
 async function readEntireTextStream(stream) {
@@ -121,7 +115,7 @@ async function doExport(mainPage) {
   const exportPage = await newPagePromise;
 
   const exportPageTitle = await exportPage.title();
-  log.result('export page opened with title: ' + exportPageTitle);
+  log(`export page opened with title: ${exportPageTitle}.`);
 
   return exportPage;
 };

--- a/tool/renderer/render.js
+++ b/tool/renderer/render.js
@@ -85,10 +85,12 @@ async function setYamlAndUpdateDiagram(page, diagramYaml) {
 
     (async () => {
       // helps with debugging, screenshots, etc
-      document.getElementById('expressIntroductionModal').style = 'display: none;';
+      document.getElementById('expressIntroductionModal').style.display = 'none';
 
       // Show the YAML tab. Not sure why but without this the diagram doesn’t render.
-      document.querySelector('a[href="#yaml"]').click();
+      document.querySelector('a[href="#yaml"]').dispatchEvent(
+        new MouseEvent('click', {view: window, bubbles: true, cancelable: true})
+      );
 
       const yamlTextArea = document.getElementById('yamlDefinition');
       yamlTextArea.value = theYaml;

--- a/tool/renderer/render.js
+++ b/tool/renderer/render.js
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// NB: here’s how I’ve been testing this on my Mac:
+// renderer $ cat ../test/data/structurizr/express/diagram_valid_cleaned.yaml | time ./render.js | open -a Preview.app -f
+
 const dataUriToBuffer = require('data-uri-to-buffer');
 const {existsSync} = require('fs');
 const path = require('path');


### PR DESCRIPTION
This changeset adds a new `renderer` “module” — really just a directory — to fc4-tool. This directory contains `render.js` and everything it needs to function (`package.json` etc). This script implements the approach recommended in #74: it uses Node, Puppeteer, and Chromium to accept a diagram’s YAML representation via stdin, load Structurizr Express (SE) via the Internet, “paste” the diagram YAML representation into SE, trigger the SE “export” feature, and then write the diagram’s PNG image to stdout.

This generally works for me when I test it (manually, on my Mac) using this command from within the `renderer` directory:

```shell
cat ../test/data/structurizr/express/diagram_valid_cleaned.yaml | time ./render.js | open -a Preview.app -f
```

Note that before that’ll work you’ll need to run `npm install` from within `renderer`.

This changeset is obviously incomplete as it includes no automated tests and no documentation updates. I’ve got that work completed but I decided to post them as follow-up PRs so that each change is more focused and thus easier to review effectively.

Specifically, this PR will be followed by these PRs:

1. One that adds an automated test and a better CLI for the script, both implemented in Clojure
1. One that gets the automated test working in our CI environment
   1. and also makes it easier to use more or less the same Docker setup locally that we use in CI
1. One that updates the docs 

That’s all I’ve got planned for now, but we’ll see.