### PR TITLE
Rendering on Alpine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,8 @@ jobs:
        - run:
           name: Download Node Dependencies (if necessary)
           working_directory: ~/project/tool/renderer
+          environment:
+            PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
           command: npm install
 
        - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,15 +39,11 @@ jobs:
 
        - run:
           name: Download Clojure Dependencies (if necessary)
-          # Clojure automatically downloads deps if necessary
-          command: clojure -R:test:test/coverage:lint -Stree
+          command: bin/download-clojure-deps
 
        - run:
           name: Download Node Dependencies (if necessary)
-          working_directory: ~/project/tool/renderer
-          environment:
-            PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: true
-          command: npm install
+          command: bin/download-node-deps
 
        - save_cache:
            name: Save Clojure Dependencies (if changed)
@@ -61,7 +57,7 @@ jobs:
            name: Save Node Dependencies (if changed)
            key: node-deps-{{checksum "renderer/package.json"}}
            paths:
-           - ~/project/tool/renderer/node_modules
+           - renderer/node_modules
 
    tool_test:
      <<: *tool_job_defaults
@@ -77,10 +73,7 @@ jobs:
 
        - run:
           name: Run tests and measure test coverage
-          # The max heap size is set to 2GB because I’ve seen OOM errors at 1GB and below. (JDK 8
-          # defaults to setting the max heap to ¼ of the total RAM, and CI containers frequently have
-          # <= 4GB RAM.)
-          command: clojure -J-Xmx2g -A:test:test/coverage
+          command: bin/tests-with-coverage
 
        - store_test_results:
           path: target/test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,13 +10,19 @@ version: 2
 tool_job_defaults: &tool_job_defaults
   working_directory: ~/project/tool
   docker:
-    - image: clojure:tools-deps-alpine
+    - image: quay.io/aviflax/clojure-node:clojure-1.9.0.394_node-10.12
 
-restore_cache_keys: &restore_cache_keys
+restore_clj_cache_keys: &restore_clj_cache_keys
   keys:
-  - deps-{{ checksum "deps.edn" }}
+  - clj-deps-{{ checksum "deps.edn" }}
   # fallback to using the latest cache if no exact match is found
-  - deps-
+  - clj-deps-
+
+restore_node_cache_keys: &restore_node_cache_keys
+  keys:
+  - node-deps-{{ checksum "renderer/package.json" }}
+  # fallback to using the latest cache if no exact match is found
+  - node-deps-
 
 jobs:
    tool_deps:
@@ -25,18 +31,33 @@ jobs:
        - checkout:
            path: ~/project
        - restore_cache:
-           <<: *restore_cache_keys
+           <<: *restore_clj_cache_keys
+           name: Restore cached Clojure dependencies
+       - restore_cache:
+           <<: *restore_node_cache_keys
+           name: Restore cached Node dependencies
+
        - run:
-          name: Download dependencies (if necessary)
+          name: Download Clojure Dependencies (if necessary)
           # Clojure automatically downloads deps if necessary
           command: clojure -R:test:test/coverage:lint -Stree
 
+       - run:
+          name: Download Node.js Dependencies (if necessary)
+          working_directory: ~/project/tool/renderer
+          command: npm install
+
        - save_cache:
-           key: deps-{{ checksum "deps.edn" }}
+           key: clj-deps-{{ checksum "deps.edn" }}
            paths:
            - .cpcache
            - ~/.m2
            - ~/.gitlibs
+
+       - save_cache:
+           key: node-deps-{{checksum "renderer/package.json"}}
+           paths:
+           - ~/project/tool/renderer/node_modules
 
    tool_test:
      <<: *tool_job_defaults
@@ -44,7 +65,11 @@ jobs:
        - checkout:
            path: ~/project
        - restore_cache:
-           <<: *restore_cache_keys
+           <<: *restore_clj_cache_keys
+           name: Restore cached Clojure dependencies
+       - restore_cache:
+           <<: *restore_node_cache_keys
+           name: Restore cached Node dependencies
 
        - run:
           name: Run tests and measure test coverage
@@ -69,7 +94,11 @@ jobs:
        - checkout:
            path: ~/project
        - restore_cache:
-           <<: *restore_cache_keys
+           <<: *restore_clj_cache_keys
+           name: Restore cached Clojure dependencies
+       - restore_cache:
+           <<: *restore_node_cache_keys
+           name: Restore cached Node dependencies
        - run:
           name: lint
           command: clojure -A:lint
@@ -80,7 +109,11 @@ jobs:
        - checkout:
            path: ~/project
        - restore_cache:
-           <<: *restore_cache_keys
+           <<: *restore_clj_cache_keys
+           name: Restore cached Clojure dependencies
+       - restore_cache:
+           <<: *restore_node_cache_keys
+           name: Restore cached Node dependencies
        - run:
            name: Download and unpack ghr
            command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ version: 2
 tool_job_defaults: &tool_job_defaults
   working_directory: ~/project/tool
   docker:
-    - image: quay.io/aviflax/clojure-node-chromium:clojure-1.9.0.394_node-10.12
+    - image: quay.io/fundingcircle/clojure-node-chromium@sha256:84a563c327d900cbfacbeabf41f941a2395ca55835135f639e8b5d656b8d7c80
 
 restore_clj_cache_keys: &restore_clj_cache_keys
   keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,11 +43,12 @@ jobs:
           command: clojure -R:test:test/coverage:lint -Stree
 
        - run:
-          name: Download Node.js Dependencies (if necessary)
+          name: Download Node Dependencies (if necessary)
           working_directory: ~/project/tool/renderer
           command: npm install
 
        - save_cache:
+           name: Save Clojure Dependencies (if changed)
            key: clj-deps-{{ checksum "deps.edn" }}
            paths:
            - .cpcache
@@ -55,6 +56,7 @@ jobs:
            - ~/.gitlibs
 
        - save_cache:
+           name: Save Node Dependencies (if changed)
            key: node-deps-{{checksum "renderer/package.json"}}
            paths:
            - ~/project/tool/renderer/node_modules

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ version: 2
 tool_job_defaults: &tool_job_defaults
   working_directory: ~/project/tool
   docker:
-    - image: quay.io/fundingcircle/clojure-node-chromium@sha256:84a563c327d900cbfacbeabf41f941a2395ca55835135f639e8b5d656b8d7c80
+    - image: quay.io/fundingcircle/clojure-node-chromium:clojure-1.9.0.394_node-10.12_alpine-3.8
 
 restore_clj_cache_keys: &restore_clj_cache_keys
   keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ version: 2
 tool_job_defaults: &tool_job_defaults
   working_directory: ~/project/tool
   docker:
-    - image: quay.io/aviflax/clojure-node:clojure-1.9.0.394_node-10.12
+    - image: quay.io/aviflax/clojure-node-chromium:clojure-1.9.0.394_node-10.12
 
 restore_clj_cache_keys: &restore_clj_cache_keys
   keys:

--- a/.circleci/images/tool/Dockerfile
+++ b/.circleci/images/tool/Dockerfile
@@ -1,0 +1,41 @@
+# I wish the “official” Node images included a tag to fix the version of Alpine
+# used, but they don’t. As of this writing in late October 2018, the base image
+# uses Alpine 3.8.
+FROM node:10.12-alpine
+
+LABEL maintainer="Avi Flax <avi.flax@fundingcircle.com>"
+LABEL description="Node and Clojure on Alpine."
+
+ENV JRE_VERSION=8.181.13-r0
+ENV CLOJURE_VERSION=1.9.0.394
+
+WORKDIR /tmp
+
+# Dependencies of Clojure.
+#
+# We might not really need rlwrap because it’s really only needed for the REPL,
+# but including it anyway just in case we need to use the REPL in the container.
+#
+# OTOH, I just noticed this:
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#dont-install-unnecessary-packages
+# which says:
+#
+# > To reduce complexity, dependencies, file sizes, and build times, avoid
+# > installing extra or unnecessary packages just because they might be “nice to
+# > have.” For example, you don’t need to include a text editor in a database
+# > image.
+#
+# ...so. Hmm.
+#
+# NB: the OpenJDK image published by Docker the company does a few things beyond
+# just apk adding the openjdk-jre package; those things might also be necessary;
+# not sure. See
+# https://github.com/docker-library/openjdk/blob/master/8/jre/alpine/Dockerfile
+# RUN echo '@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
+RUN apk add --update --no-cache openjdk8-jre=$JRE_VERSION bash curl
+# rlwrap@testing
+
+# Clojure itself
+RUN wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh \
+      && chmod +x linux-install-$CLOJURE_VERSION.sh \
+      && ./linux-install-$CLOJURE_VERSION.sh

--- a/.circleci/images/tool/Dockerfile
+++ b/.circleci/images/tool/Dockerfile
@@ -33,4 +33,4 @@ RUN wget -q https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.
 # think rm -Rf /usr/lib/chromium should work, but I had some trouble with that.
 # I’m not sure why; it could be my lack of experience working with remote Docker
 # repositories. Might be worth trying again at some point.
-RUN apk -q --no-progress add --no-cache udev ttf-freefont chromium
+RUN apk -q --no-progress add --no-cache udev ttf-freefont libc6-compat chromium

--- a/.circleci/images/tool/Dockerfile
+++ b/.circleci/images/tool/Dockerfile
@@ -4,38 +4,28 @@
 FROM node:10.12-alpine
 
 LABEL maintainer="Avi Flax <avi.flax@fundingcircle.com>"
-LABEL description="Node and Clojure on Alpine."
+LABEL description="Node, Clojure, and Chromium on Alpine"
 
 ENV JRE_VERSION=8.181.13-r0
 ENV CLOJURE_VERSION=1.9.0.394
 
 WORKDIR /tmp
 
+RUN apk update
+
 # Dependencies of Clojure.
-#
-# We might not really need rlwrap because it’s really only needed for the REPL,
-# but including it anyway just in case we need to use the REPL in the container.
-#
-# OTOH, I just noticed this:
-# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#dont-install-unnecessary-packages
-# which says:
-#
-# > To reduce complexity, dependencies, file sizes, and build times, avoid
-# > installing extra or unnecessary packages just because they might be “nice to
-# > have.” For example, you don’t need to include a text editor in a database
-# > image.
-#
-# ...so. Hmm.
-#
 # NB: the OpenJDK image published by Docker the company does a few things beyond
 # just apk adding the openjdk-jre package; those things might also be necessary;
 # not sure. See
 # https://github.com/docker-library/openjdk/blob/master/8/jre/alpine/Dockerfile
-# RUN echo '@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories
-RUN apk add --update --no-cache openjdk8-jre=$JRE_VERSION bash curl
-# rlwrap@testing
+RUN apk -q --no-progress add --no-cache openjdk8-jre=$JRE_VERSION bash curl
 
 # Clojure itself
-RUN wget https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh \
+RUN wget -q https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh \
       && chmod +x linux-install-$CLOJURE_VERSION.sh \
       && ./linux-install-$CLOJURE_VERSION.sh
+
+# Add the dependencies of the Chromium that Puppeteer downloads for its own use.
+# We don’t actually need this Chromium, only its dependencies.
+RUN apk -q --no-progress add --no-cache udev ttf-freefont chromium \
+    && apk -q --no-progress del chromium

--- a/.circleci/images/tool/Dockerfile
+++ b/.circleci/images/tool/Dockerfile
@@ -24,12 +24,9 @@ RUN wget -q https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.
       && chmod +x linux-install-$CLOJURE_VERSION.sh \
       && ./linux-install-$CLOJURE_VERSION.sh
 
-# Add the dependencies of the Chromium that Puppeteer downloads for its own use.
-# We don’t actually need this Chromium, only its dependencies. Hypothetically we
-# could `apk del chromium` after installing it all, in order to reduce the image
-# size, but that also deletes all the dependencies that would then be unneeded,
-# as far as apk knows. So maybe we’ll figure that out at some point. Actually I
-# think rm -Rf /usr/lib/chromium should work, but I had some trouble with that.
-# I’m not sure why; it could be my lack of experience working with remote Docker
-# repositories. Might be worth trying again at some point.
-RUN apk -q --no-progress add --no-cache udev ttf-freefont libc6-compat chromium
+# We need Chromium for automated rendering with Puppeteer; see
+#   https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
+# This specific version of Chromium is locked to the specific version of
+# Puppeteer that we’re using as per the above page; see also
+#   <project-root>/tool/renderer/package.json
+RUN apk -q --no-progress --no-cache add chromium=68.0.3440.75-r0

--- a/.circleci/images/tool/Dockerfile
+++ b/.circleci/images/tool/Dockerfile
@@ -1,7 +1,8 @@
 # I wish the “official” Node images included a tag to fix the version of Alpine
-# used, but they don’t. As of this writing in late October 2018, the base image
-# uses Alpine 3.8.
-FROM node:10.12-alpine
+# used, but they don’t. Therefore we’re specifing a specific image hash to use
+# rather than a tag.
+# This base image at this hash uses Node 10.12 and Alpine 3.8:
+FROM node@sha256:1e3e3e7ffc965511c5d4f4e90ec5d9cabee95b5b1fbcd49eb6a2289f425cf183
 
 LABEL maintainer="Avi Flax <avi.flax@fundingcircle.com>"
 LABEL description="Node, Clojure, and Chromium on Alpine"
@@ -11,14 +12,12 @@ ENV CLOJURE_VERSION=1.9.0.394
 
 WORKDIR /tmp
 
-RUN apk update
-
-# Dependencies of Clojure.
+# Dependencies of Clojure and the Clojure installer.
 # NB: the OpenJDK image published by Docker the company does a few things beyond
 # just apk adding the openjdk-jre package; those things might also be necessary;
 # not sure. See
 # https://github.com/docker-library/openjdk/blob/master/8/jre/alpine/Dockerfile
-RUN apk -q --no-progress add --no-cache openjdk8-jre=$JRE_VERSION bash curl
+RUN apk -q --no-progress --no-cache add openjdk8-jre=$JRE_VERSION bash curl
 
 # Clojure itself
 RUN wget -q https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh \

--- a/.circleci/images/tool/Dockerfile
+++ b/.circleci/images/tool/Dockerfile
@@ -26,6 +26,11 @@ RUN wget -q https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.
       && ./linux-install-$CLOJURE_VERSION.sh
 
 # Add the dependencies of the Chromium that Puppeteer downloads for its own use.
-# We don’t actually need this Chromium, only its dependencies.
-RUN apk -q --no-progress add --no-cache udev ttf-freefont chromium \
-    && apk -q --no-progress del chromium
+# We don’t actually need this Chromium, only its dependencies. Hypothetically we
+# could `apk del chromium` after installing it all, in order to reduce the image
+# size, but that also deletes all the dependencies that would then be unneeded,
+# as far as apk knows. So maybe we’ll figure that out at some point. Actually I
+# think rm -Rf /usr/lib/chromium should work, but I had some trouble with that.
+# I’m not sure why; it could be my lack of experience working with remote Docker
+# repositories. Might be worth trying again at some point.
+RUN apk -q --no-progress add --no-cache udev ttf-freefont chromium

--- a/tool/.dockerignore
+++ b/tool/.dockerignore
@@ -1,0 +1,3 @@
+.cpcache
+target
+**/node_modules

--- a/tool/Dockerfile.test
+++ b/tool/Dockerfile.test
@@ -2,11 +2,10 @@
 # using the tool because the tool requires access to your clipboard, which is
 # very tricky from within a Docker container.
 
-FROM clojure:tools-deps-alpine
-
+FROM quay.io/aviflax/clojure-node-chromium:clojure-1.9.0.394_node-10.12
 LABEL maintainer="Avi Flax <avi.flax@fundingcircle.com>"
 
-WORKDIR /code
+WORKDIR /tool
 
 # Copy deps.edn then invoke `clojure` just to download the deps, separately from
 # and prior to copying the app code so that we don’t have to re-download deps
@@ -14,9 +13,18 @@ WORKDIR /code
 COPY deps.edn ./
 RUN clojure -R:test -Stree
 
-# Now copy all the app code.
+# Same deal for Node dependencies for the renderer
+COPY renderer/package*.json ./renderer/
+RUN cd renderer && npm install
+
+# rlwrap is handy in case we need to run a REPL in a container
+RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+RUN apk add --no-cache rlwrap@testing
+
+# Now copy *all* the code.
 COPY . ./
 
+# Set command that runs the tests
 # The max heap size is set to 2GB because I’ve seen OOM errors at 1GB and below. (JDK 8 defaults to
 # setting the max heap to ¼ of the total RAM, and containers frequently have <= 4GB RAM.)
-ENTRYPOINT ["clojure", "-J-Xmx2g", "-A:test:test/run"]
+CMD ["clojure", "-J-Xmx2g", "-A:test:test/run"]

--- a/tool/Dockerfile.test
+++ b/tool/Dockerfile.test
@@ -7,15 +7,17 @@ LABEL maintainer="Avi Flax <avi.flax@fundingcircle.com>"
 
 WORKDIR /tool
 
-# Copy deps.edn then invoke `clojure` just to download the deps, separately from
-# and prior to copying the app code so that we don’t have to re-download deps
-# every time the app code changes.
-COPY deps.edn ./
-RUN clojure -R:test -Stree
+# Copy Clojure’s deps.edn and Node’s package files then download the deps
+# separately from and prior to copying the app code so that we don’t have to
+# re-download deps every time the app code changes.
 
-# Same deal for Node dependencies for the renderer
+COPY deps.edn ./
+COPY bin/download-clojure-deps bin/
+RUN bin/download-clojure-deps
+
 COPY renderer/package*.json ./renderer/
-RUN cd renderer && npm install
+COPY bin/download-node-deps bin/
+RUN bin/download-node-deps
 
 # rlwrap is handy in case we need to run a REPL in a container
 RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
@@ -23,8 +25,3 @@ RUN apk add --no-cache rlwrap@testing
 
 # Now copy *all* the code.
 COPY . ./
-
-# Set command that runs the tests
-# The max heap size is set to 2GB because I’ve seen OOM errors at 1GB and below. (JDK 8 defaults to
-# setting the max heap to ¼ of the total RAM, and containers frequently have <= 4GB RAM.)
-CMD ["clojure", "-J-Xmx2g", "-A:test:test/run"]

--- a/tool/Dockerfile.test
+++ b/tool/Dockerfile.test
@@ -2,7 +2,7 @@
 # using the tool because the tool requires access to your clipboard, which is
 # very tricky from within a Docker container.
 
-FROM quay.io/fundingcircle/clojure-node-chromium@sha256:84a563c327d900cbfacbeabf41f941a2395ca55835135f639e8b5d656b8d7c80
+FROM quay.io/fundingcircle/clojure-node-chromium:clojure-1.9.0.394_node-10.12_alpine-3.8
 LABEL maintainer="Avi Flax <avi.flax@fundingcircle.com>"
 
 WORKDIR /tool
@@ -20,8 +20,7 @@ COPY bin/download-node-deps bin/
 RUN bin/download-node-deps
 
 # rlwrap is handy in case we need to run a REPL in a container
-RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
-RUN apk add --no-cache rlwrap@testing
+RUN apk add --no-cache --repository=http://nl.alpinelinux.org/alpine/edge/testing rlwrap
 
 # Now copy *all* the code.
 COPY . ./

--- a/tool/Dockerfile.test
+++ b/tool/Dockerfile.test
@@ -2,7 +2,7 @@
 # using the tool because the tool requires access to your clipboard, which is
 # very tricky from within a Docker container.
 
-FROM quay.io/aviflax/clojure-node-chromium:clojure-1.9.0.394_node-10.12
+FROM quay.io/fundingcircle/clojure-node-chromium@sha256:84a563c327d900cbfacbeabf41f941a2395ca55835135f639e8b5d656b8d7c80
 LABEL maintainer="Avi Flax <avi.flax@fundingcircle.com>"
 
 WORKDIR /tool

--- a/tool/bin/download-all-deps
+++ b/tool/bin/download-all-deps
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -ex
+
+./download-clojure-deps
+./download-node-deps

--- a/tool/bin/download-clojure-deps
+++ b/tool/bin/download-clojure-deps
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -ex
+
+# Clojure automatically downloads deps if necessary
+clojure -R:test:test/coverage:lint -Stree

--- a/tool/bin/download-node-deps
+++ b/tool/bin/download-node-deps
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -ex
+
+# We’re using the Chromium installed by APK as recommended here:
+#   https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
+# npm install automaticaly downloads deps if necessary
+cd renderer && npm install

--- a/tool/bin/run
+++ b/tool/bin/run
@@ -9,4 +9,10 @@
 
 set -ex
 docker build -f Dockerfile.test -t fc4-test .
-docker run --rm fc4-test "$@"
+
+# You might think this command should include --rm so as not to litter the system with containers,
+# and that’d be reasonable, BUT it can also make debugging harder. Sometimes when the tests fail
+# they write out files that are meant to help with debugging; if the container is deleted as soon
+# as it exits then those files are gone. So you might want to run `docker container prune` every
+# once in awhile ;)
+docker run fc4-test "$@"

--- a/tool/bin/run
+++ b/tool/bin/run
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+# Run commands using ../Dockerfile.test
+# e.g. from <repo-root>/tool:  bin/run bin/tests ... not super elegant but what
+# can I do.
+# alternatively:
+# $ export PATH=$PATH:$(pwd)/bin
+# $ run bin/tests
+
+set -ex
+docker build -f Dockerfile.test -t fc4-test .
+docker run --rm fc4-test "$@"

--- a/tool/bin/run-all-tests
+++ b/tool/bin/run-all-tests
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-docker build -f Dockerfile.test -t fc4-test .
-docker run --rm fc4-test

--- a/tool/bin/run-all-tests
+++ b/tool/bin/run-all-tests
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+docker build -f Dockerfile.test -t fc4-test .
+docker run --rm fc4-test

--- a/tool/bin/tests
+++ b/tool/bin/tests
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -ex
+
+# The max heap size is set to 2GB because I’ve seen OOM errors at 1GB and below. (JDK 8
+# defaults to setting the max heap to ¼ of the total RAM, and CI containers frequently have
+# <= 4GB RAM.)
+clojure -J-Xmx2g -A:test:test/run

--- a/tool/bin/tests-with-coverage
+++ b/tool/bin/tests-with-coverage
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -ex
+
+# The max heap size is set to 2GB because I’ve seen OOM errors at 1GB and below. (JDK 8
+# defaults to setting the max heap to ¼ of the total RAM, and CI containers frequently have
+# <= 4GB RAM.)
+clojure -J-Xmx2g -A:test:test/coverage


### PR DESCRIPTION
This is part of the implementation for #74 and a follow-up to #80 and #82.

#82 added a Clojure wrapper and an automated test for the Node renderer added in #80, but wasn’t able to build successfully in CI as the CI build environment needed some updates.

This PR makes those updates, and also leverages those updates to enable running all the tests locally in Docker using the same exact environment and configuration as the CI build environment.

This PR does not include the necessary updates to the docs. Those are coming shortly in a follow-up PR. I kept them separate because _this_ PR is already quite big and I didn’t want this to be too difficult too review.

### Before Merging

* [ ] ~~#82 must merge~~
* [ ] ~~this PR must be re-pointed to master~~

I’ve realized the above steps won’t work. For an explanation please see the note at the end of the description of #82.