### PR TITLE
Build, package, and deploy an Uberjar artifact containing AOT-compiled code

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,30 +1,31 @@
 version: 2
 
-# In many of the jobs below, you’ll see `working_directory` specified, and that
-# the `checkout` step has a different path specified (the default path). This is
-# because it’s a little tricky to get `working_directory` and `checkout` to work
-# together when I want the working directory for all steps *except*
-# `checkout` to be a subdirectory of the project — because by default,
-# `checkout` checks out into the specified `working_directory`. I found this
-# solution here: https://stackoverflow.com/a/50570581/7012
+# All the tool_* jobs specify the checkout path, and then set a
+# `working_directory` that’s different than the default and is _underneath_ the
+# checkout path. This is because it’s a little tricky to get `working_directory`
+# and `checkout` to work together when I want the working directory for all
+# steps *except* `checkout` to be a subdirectory of the project — because by
+# default, `checkout` checks out into the specified `working_directory`. I found
+# this solution here: https://stackoverflow.com/a/50570581/7012
+tool_job_defaults: &tool_job_defaults
+  working_directory: ~/project/tool
+  docker:
+    - image: clojure:tools-deps-alpine
+
+restore_cache_keys: &restore_cache_keys
+  keys:
+  - deps-{{ checksum "deps.edn" }}
+  # fallback to using the latest cache if no exact match is found
+  - deps-
 
 jobs:
    tool_deps:
-     docker:
-       - image: clojure:tools-deps-alpine
-
-     working_directory: ~/project/tool
-
+     <<: *tool_job_defaults
      steps:
        - checkout:
            path: ~/project
-
        - restore_cache:
-           keys:
-           - deps-{{ checksum "deps.edn" }}
-           # fallback to using the latest cache if no exact match is found
-           - deps-
-
+           <<: *restore_cache_keys
        - run:
           name: Download dependencies (if necessary)
           # Clojure automatically downloads deps if necessary
@@ -38,20 +39,12 @@ jobs:
            - ~/.gitlibs
 
    tool_test:
-     docker:
-       - image: clojure:tools-deps-alpine
-
-     working_directory: ~/project/tool
-
+     <<: *tool_job_defaults
      steps:
        - checkout:
            path: ~/project
-
        - restore_cache:
-           keys:
-           - deps-{{ checksum "deps.edn" }}
-           # fallback to using the latest cache if no exact match is found
-           - deps-
+           <<: *restore_cache_keys
 
        - run:
           name: Run tests and measure test coverage
@@ -71,33 +64,62 @@ jobs:
           command: bash <(curl -s https://codecov.io/bash)
 
    tool_lint:
-     docker:
-       - image: clojure:tools-deps-alpine
-
-     working_directory: ~/project/tool
-
+     <<: *tool_job_defaults
      steps:
        - checkout:
            path: ~/project
-
        - restore_cache:
-           keys:
-           - deps-{{ checksum "deps.edn" }}
-           # fallback to using the latest cache if no exact match is found
-           - deps-
-
+           <<: *restore_cache_keys
        - run:
           name: lint
           command: clojure -A:lint
+
+   tool_publish_jar:
+     <<: *tool_job_defaults
+     steps:
+       - checkout:
+           path: ~/project
+       - restore_cache:
+           <<: *restore_cache_keys
+       - run:
+           name: Download and unpack ghr
+           command: |
+             wget https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz
+             tar -xzf ghr_v0.12.0_linux_amd64.tar.gz --strip-components 1 ghr_v0.12.0_linux_amd64/ghr
+       - run:
+           name: Build Uberjar
+           command: bin/uberjar
+       - run:
+           name: Create GitHub Release and upload uberjar to it
+           command: ./ghr -t ${GITHUB_TOKEN:-GITHUB_TOKEN_NOT_SET} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG:-CIRCLE_TAG_NOT_SET} target/fc4.jar
 
 workflows:
   version: 2
   tool:
     jobs:
-      - tool_deps
+      - tool_deps:
+          filters:
+            tags:
+              only: /.*/
       - tool_test:
           requires:
             - tool_deps
+          filters:
+            tags:
+              only: /.*/
       - tool_lint:
           requires:
             - tool_deps
+          filters:
+            tags:
+              only: /.*/
+      - tool_publish_jar:
+          requires:
+            - tool_deps
+            - tool_test
+            - tool_lint
+          filters:
+            tags:
+              only: /.*/
+            branches:
+              ignore: /.*/

--- a/methodology/authoring_workflow.md
+++ b/methodology/authoring_workflow.md
@@ -8,8 +8,8 @@ Once a basic YAML file has been created with some initial contents, the basic au
 
 1. Create a new git branch in your local instance of [the diagram repository](repository.md)
 1. In your text editor: either create a new diagram source file or open an existing diagram source file
-1. In a terminal, in your `fc4` working dir, run `cd tool && ./wcb`
-   1. This starts the tool in a mode wherein it will watch your clipboard for diagram source YAML and process (clean up) that YAML when it sees that it’s been changed.
+1. In a terminal run `java -jar path/to/fc4.jar`
+   1. This starts [fc4-tool](toolset.md#fc4-tool) in a mode wherein it will watch your clipboard for diagram source YAML and process (clean up) that YAML when it sees that it’s been changed.
 1. In your text editor, add/revise elements and relationships, then select-all and cut the diagram source from your editor into your system clipboard.
    1. This will cause fc4-tool to process the contents of your clipboard.
 1. Switch to [Structurizr Express](https://structurizr.com/help/express) (SE) » paste the source into the YAML textarea » press tab to blur the textarea

--- a/tool/.gitignore
+++ b/tool/.gitignore
@@ -1,2 +1,5 @@
 .cpcache
 target
+
+# the pom file is created by Cambada (used in the deps.edn alias :uberjar)
+pom.xml

--- a/tool/README.md
+++ b/tool/README.md
@@ -112,10 +112,8 @@ source code is formatted incorrectly. Coming soon!
 You’ll need to be using Java 9 or 10; 11 or higher cannot currently compile the project (see [issue #85](https://github.com/FundingCircle/fc4-framework/issues/85)).
 
 ```shell
-rm -Rf src/test_utils
-clojure -A:uberjar
-git reset --hard HEAD # undo the deletion above BE CAREFUL NOT TO LOSE CHANGES
-mv target/tool-1.0.0-SNAPSHOT-standalone.jar target/fc4.jar
+# From <repo-root>/tool/ run:
+bin/uberjar
 ```
 
 Since you need to use Java 8/9/10 to compile the project but then Java 11 to validate the uberjar, you might find [jenv](http://www.jenv.be/) useful. (I discovered it via [Multiple JVM versions on macOS](https://pete-woods.com/2018/01/multiple-jvm-versions-on-macos/) by Pete Woods.)

--- a/tool/README.md
+++ b/tool/README.md
@@ -107,6 +107,19 @@ via [cljfmt-runner](https://github.com/JamesLaverack/cljfmt-runner).
 We’ll soon be integrating a lint run into our CI builds so they’ll fail if any
 source code is formatted incorrectly. Coming soon!
 
+## Building an Uberjar
+
+You’ll need to be using Java 9 or 10; 11 or higher cannot currently compile the project (see [issue #85](https://github.com/FundingCircle/fc4-framework/issues/85)).
+
+```shell
+rm -Rf src/test_utils
+clojure -A:uberjar
+git reset --hard HEAD # undo the deletion above BE CAREFUL NOT TO LOSE CHANGES
+mv target/tool-1.0.0-SNAPSHOT-standalone.jar target/fc4.jar
+```
+
+Since you need to use Java 8/9/10 to compile the project but then Java 11 to validate the uberjar, you might find [jenv](http://www.jenv.be/) useful. (I discovered it via [Multiple JVM versions on macOS](https://pete-woods.com/2018/01/multiple-jvm-versions-on-macos/) by Pete Woods.)
+
 ## Contributors
 
 * @99-not-out

--- a/tool/README.md
+++ b/tool/README.md
@@ -20,30 +20,18 @@ As explained in
 
 ## Setup
 
-1. Install Clojure as per [this guide](https://clojure.org/guides/getting_started)
-   1. This project uses the new Clojure CLI (`clj`) and
-      [tools.deps](https://clojure.org/guides/deps_and_cli), both of which are installed by
-      [the new official Clojure installers](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools)
-      released alongside Clojure 1.9. If you’ve been working with Clojure for awhile, you might
-      not have these tools installed. Try `which clj` to check, and if that prints a blank line,
-      try running the appropriate
-      [installer](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools).
-2. Clone [this repo](https://github.com/FundingCircle/fc4-framework)
-3. `cd` into the repo and then `cd tool`
-4. To install the dependencies, run: `clojure -Sdescribe'`
+1. Have a Java Runtime Environment (JRE) or Java Development Kit (JDK) installed
+   1. On MacOS if you have [Homebrew](https://brew.sh/) you can run `brew cask install adoptopenjdk`
+1. Download `fc4.jar` from the latest release on [the releases page](https://github.com/FundingCircle/fc4-framework/releases)
 
-## Basic Usage
 
-1. Have `clj` installed ([guide](https://clojure.org/guides/getting_started))
-1. Run in your shell, from the root of the repo: `cd tool && ./wcb`
-
-## Full Usage Workflow
+## Basic Usage Workflow
 
 As explained in [The Authoring Workflow](https://fundingcircle.github.io/fc4-framework/methodology/authoring_workflow.html) section of
 [the FC4 Methodology](https://fundingcircle.github.io/fc4-framework/methodology/):
 
 > 1. In your text editor: either create a new diagram source file or open an existing diagram source file
-> 1. In a terminal, in your `fc4` working dir, run `cd tool && ./wcb`
+> 1. In a terminal run `java -jar path/to/fc4.jar`
 >    1. This starts the tool in a mode wherein it will watch your clipboard for diagram source YAML and process (clean up) that YAML when it sees that it’s been changed.
 > 1. In your text editor, add/revise elements and relationships, then select-all and cut the diagram source from your editor into your system clipboard.
 >    1. This will cause fc4-tool to process the contents of your clipboard.
@@ -55,6 +43,18 @@ As explained in [The Authoring Workflow](https://fundingcircle.github.io/fc4-fra
 >    1. This will cause fc4-tool to process the contents of your clipboard.
 > 1. Paste the diagram source back into the SE YAML textarea so as to re-render the diagram, now that the elements have been “snapped” to a virtual grid.
 > 1. Continue to cut and past the diagram source between your text editor and SE, using SE to preview and adjust the rendered diagram, while fc4-tool cleans up the diagram as you work.
+
+## Requirements and Prerequisites for Development and Testing
+
+### Required
+
+* Java 8/9/10
+  * The tool cannot currently compile on Java 11 due to [an incompatibility](https://github.com/circleci/clj-yaml/issues/22) in a dependency of a dependency. Therefore you are recommended to use Java 8, 9, or 10 to develop and/or test the tool.
+
+### Recommended
+
+* [Docker](https://www.docker.com/)
+  * For [running the tests](#running-the-tests)
 
 ## Running the Tests
 

--- a/tool/bin/uberjar
+++ b/tool/bin/uberjar
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+## Run this from <project-root>/tool/
+
+set -e
+
+# We don’t want this source tree src/test_utils to be included in the set of
+# source files that will be compiled, mainly because they can only compile
+# successfully if certain test dependencies are included, such as eftest and
+# cloverage. We don’t want those dependencies to be included in the deployment
+# artifact (uberjar) because they’d wastefully inflate its size, so right now,
+# unless and until we modify Cambada or switch to a different tool for building
+# the uberjar, this hack suffices.
+tmp_src_dir=$(mktemp -d)
+mv src/test_utils "$tmp_src_dir/"
+trap 'mv $tmp_src_dir/test_utils src/' EXIT
+
+clojure -A:uberjar
+
+target_path="target/fc4.jar"
+
+mv target/tool-1.0.0-SNAPSHOT-standalone.jar "$target_path"
+
+echo "Successfully created $target_path"

--- a/tool/deps.edn
+++ b/tool/deps.edn
@@ -37,17 +37,7 @@
 
            :lint/fix      {:main-opts   ["-m" "cljfmt-runner.fix"]}
 
-           :uberjar       {:extra-deps  {luchiniatwork/cambada {:mvn/version "1.0.0"}
-                                         ;; NB before you run this alias you’ll need to either
-                                         ;; temporarily delete src/test_utils or un-comment-out the
-                                         ;; two following deps.
-                                         ;; This is because Cambada includes all
-                                         ;; source files under `src` which unfortunately includes
-                                         ;; `src/test_utils` and the source files in that dir require
-                                         ;; these deps.
-                                         ; cloverage                  {:mvn/version "1.0.13"}
-                                         ; eftest                     {:mvn/version "0.5.3"}
-                                        }
+           :uberjar       {:extra-deps  {luchiniatwork/cambada {:mvn/version "1.0.0"}}
                            :main-opts   ["-m" "cambada.uberjar"
                                          "-m" "fc4.cli.wcb"
                                          "--aot" "all"

--- a/tool/deps.edn
+++ b/tool/deps.edn
@@ -37,7 +37,21 @@
 
            :lint/fix      {:main-opts   ["-m" "cljfmt-runner.fix"]}
 
-           :outdated      {:extra-deps  {olical/depot               {:mvn/version "1.2.0"}}
-                           :main-opts   ["-m" "depot.outdated.main"]}
+           :uberjar       {:extra-deps  {luchiniatwork/cambada {:mvn/version "1.0.0"}
+                                         ;; NB before you run this alias you’ll need to either
+                                         ;; temporarily delete src/test_utils or un-comment-out the
+                                         ;; two following deps.
+                                         ;; This is because Cambada includes all
+                                         ;; source files under `src` which unfortunately includes
+                                         ;; `src/test_utils` and the source files in that dir require
+                                         ;; these deps.
+                                         ; cloverage                  {:mvn/version "1.0.13"}
+                                         ; eftest                     {:mvn/version "0.5.3"}
+                                        }
+                           :main-opts   ["-m" "cambada.uberjar"
+                                         "-m" "fc4.cli.wcb"
+                                         "--aot" "all"
+                                         "--no-copy-source"
+                                         "--out" "target"]}
 
-           :clj-next      {:override-deps {org.clojure/clojure      {:mvn/version "1.10.0-beta4"}}}}}
+           :clj-next      {:override-deps {org.clojure/clojure {:mvn/version "1.10.0-beta4"}}}}}

--- a/tool/src/cli/fc4/cli/wcb.clj
+++ b/tool/src/cli/fc4/cli/wcb.clj
@@ -1,5 +1,6 @@
 (ns fc4.cli.wcb
   "wcb = Watch ClipBoard"
+  (:gen-class)
   (:require [fc4.integrations.structurizr.express.clipboard :refer [wcb]]
             [clojure.core.async :as ca :refer [<!!]]))
 

--- a/tool/src/main/fc4/integrations/structurizr/express/clipboard.clj
+++ b/tool/src/main/fc4/integrations/structurizr/express/clipboard.clj
@@ -4,7 +4,7 @@
              :as ed
              :refer [probably-diagram-yaml? process-file]])
   (:import [java.awt Toolkit]
-           [java.awt.datatransfer DataFlavor StringSelection])
+           [java.awt.datatransfer Clipboard DataFlavor StringSelection])
   (:refer-clojure :exclude [slurp spit]))
 
 ; Suppress the Java icon from popping up and grabbing focus on MacOS.
@@ -15,7 +15,9 @@
 ;; This was a simple var at one point but that broke CI builds, which run on
 ;; headless machines; therefore this needs to be a function and it shouldn’t be
 ;; called during CI test runs.
-(defn clipboard [] (.getSystemClipboard (Toolkit/getDefaultToolkit)))
+(defn clipboard ^Clipboard
+  []
+  (.getSystemClipboard (Toolkit/getDefaultToolkit)))
 
 ;; based on code found at https://gist.github.com/Folcon/1167903
 (def string-flavor (DataFlavor/stringFlavor))


### PR DESCRIPTION
Fixes #85 which revealed that the tool can’t be compiled on Java 11. This means that the current recommended approach for users to use the tool, by checkout out the source code and running it “from the source” is now [even more](https://github.com/FundingCircle/fc4-framework/pull/76) problematic; it just won’t work if a user has Java 11.

While the project won’t _compile_ on Java 11, once compiled to Java bytecode it will _run_ just fine on Java 11. So I figured: let’s compile in CI, whenever a tag is created/pushed, then create a GitHub “release” and upload the uberjar to the release.