### PR TITLE
Support recent/current versions of Chrome/Chromium

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ version: 2
 tool_job_defaults: &tool_job_defaults
   working_directory: ~/project/tool
   docker:
-    - image: quay.io/fundingcircle/clojure-node-chromium:clojure-1.9.0.394_node-11.1_debian-stretch
+    - image: quay.io/fundingcircle/clojure-node-chromium:clojure-1.9.0.394_node-10.13_debian-stretch
 
 restore_cache_clj: &restore_cache_clj
   name: Restore cached Clojure dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ version: 2
 tool_job_defaults: &tool_job_defaults
   working_directory: ~/project/tool
   docker:
-    - image: quay.io/fundingcircle/clojure-node-chromium:clojure-1.9.0.394_node-10.12_alpine-3.8
+    - image: quay.io/fundingcircle/clojure-node-chromium:clojure-1.9.0.394_node-11.1_debian-stretch
 
 restore_cache_clj: &restore_cache_clj
   name: Restore cached Clojure dependencies
@@ -118,9 +118,6 @@ jobs:
        - run:
            name: Download dependencies needed for building dist package
            command: bin/download-pkg-deps
-           environment:
-             # Workaround for https://github.com/nodejs/docker-node/issues/813
-             npm_config_unsafe_perm: true
        - run:
            name: Create distribution packages
            command: |

--- a/.circleci/images/tool/Dockerfile
+++ b/.circleci/images/tool/Dockerfile
@@ -1,32 +1,21 @@
-# I wish the “official” Node images included a tag to fix the version of Alpine
-# used, but they don’t. Therefore we’re specifing a specific image hash to use
-# rather than a tag.
-# This base image at this hash uses Node 10.12 and Alpine 3.8:
-FROM node@sha256:1e3e3e7ffc965511c5d4f4e90ec5d9cabee95b5b1fbcd49eb6a2289f425cf183
+FROM node:11.1.0-stretch
 
 LABEL maintainer="Avi Flax <avi.flax@fundingcircle.com>"
-LABEL description="Node, Clojure, and Chromium on Alpine"
+LABEL description="Node 11, Clojure 1.9, and Chromium 70 on Debian Stretch"
 
-ENV JRE_VERSION=8.181.13-r0
+ENV JRE_VERSION=8u181-b13-2~deb9u1
 ENV CLOJURE_VERSION=1.9.0.394
+ENV CHROMIUM_VERSION=70.0.3538.67-1~deb9u1
 
 WORKDIR /tmp
 
-# Dependencies of Clojure and the Clojure installer.
-# NB: the OpenJDK image published by Docker the company does a few things beyond
-# just apk adding the openjdk-jre package; those things might also be necessary;
-# not sure. See
-# https://github.com/docker-library/openjdk/blob/master/8/jre/alpine/Dockerfile
-RUN apk -q --no-progress --no-cache add openjdk8-jre=$JRE_VERSION bash curl
+# Install dependencies of the Renderer and Clojure
+# We’re including rlwrap just because it’s handy in case we need to run a REPL
+# in a container, for debugging.
+RUN apt-get update -yq
+RUN apt-get install -yq chromium=$CHROMIUM_VERSION openjdk-8-jre=$JRE_VERSION rlwrap
 
-# Clojure itself
+# Install Clojure
 RUN wget -q https://download.clojure.org/install/linux-install-$CLOJURE_VERSION.sh \
       && chmod +x linux-install-$CLOJURE_VERSION.sh \
       && ./linux-install-$CLOJURE_VERSION.sh
-
-# We need Chromium for automated rendering with Puppeteer; see
-#   https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
-# This specific version of Chromium is locked to the specific version of
-# Puppeteer that we’re using as per the above page; see also
-#   <project-root>/tool/renderer/package.json
-RUN apk -q --no-progress --no-cache add chromium=68.0.3440.75-r0

--- a/.circleci/images/tool/Dockerfile
+++ b/.circleci/images/tool/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:11.1.0-stretch
+FROM node:10.13.0-stretch
 
 LABEL maintainer="Avi Flax <avi.flax@fundingcircle.com>"
-LABEL description="Node 11, Clojure 1.9, and Chromium 70 on Debian Stretch"
+LABEL description="Node 10 (LTS), Clojure 1.9, and Chromium 70 on Debian Stretch"
 
 ENV JRE_VERSION=8u181-b13-2~deb9u1
 ENV CLOJURE_VERSION=1.9.0.394

--- a/tool/Dockerfile.test
+++ b/tool/Dockerfile.test
@@ -6,7 +6,7 @@
 # we could use docker-compose to mount a data directory and run the tool from
 # within a container.
 
-FROM quay.io/fundingcircle/clojure-node-chromium:clojure-1.9.0.394_node-11.1_debian-stretch
+FROM quay.io/fundingcircle/clojure-node-chromium:clojure-1.9.0.394_node-10.13_debian-stretch
 LABEL maintainer="Avi Flax <avi.flax@fundingcircle.com>"
 
 WORKDIR /tool

--- a/tool/Dockerfile.test
+++ b/tool/Dockerfile.test
@@ -6,7 +6,7 @@
 # we could use docker-compose to mount a data directory and run the tool from
 # within a container.
 
-FROM quay.io/fundingcircle/clojure-node-chromium:clojure-1.9.0.394_node-10.12_alpine-3.8
+FROM quay.io/fundingcircle/clojure-node-chromium:clojure-1.9.0.394_node-11.1_debian-stretch
 LABEL maintainer="Avi Flax <avi.flax@fundingcircle.com>"
 
 WORKDIR /tool
@@ -22,9 +22,6 @@ RUN bin/download-clojure-deps
 COPY renderer/package*.json ./renderer/
 COPY bin/download-node-deps bin/
 RUN bin/download-node-deps
-
-# rlwrap is handy in case we need to run a REPL in a container
-RUN apk add --no-cache --repository=http://nl.alpinelinux.org/alpine/edge/testing rlwrap
 
 # Now copy *all* the code.
 COPY . ./

--- a/tool/README.md
+++ b/tool/README.md
@@ -28,14 +28,13 @@ As explained in
 
 1. A [Java Runtime Environment (JRE)](https://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html) or [Java Development Kit (JDK)](https://adoptopenjdk.net/)
    1. On MacOS if you have [Homebrew](https://brew.sh/) you can run `brew cask install adoptopenjdk`
-1. An installation of [Chrome](https://www.google.com/chrome/browser/) or [Chromium](https://www.chromium.org/Home) **68**
-   1. **Must be version 68**
-      1. Direct download links for Chromium: [MacOS](https://storage.googleapis.com/chromium-browser-snapshots/Mac/555668/chrome-mac.zip), [Linux](https://storage.googleapis.com/chromium-browser-snapshots/Linux_x64/555668/chrome-linux.zip)
+1. An installation of [Chrome](https://www.google.com/chrome/browser/) or [Chromium](https://www.chromium.org/Home) **70–72** (inclusive)
    1. On MacOS:
+      1. If you have [Homebrew](https://brew.sh/) you can run `brew cask install chromium`
       1. Chromium/Chrome must be at either `/Applications/Chromium.app` or `/Applications/Google Chrome.app`
-      1. Chromium takes precedence, so if you have Chromium and Chrome installed, only Chromium needs to be version 68
-   1. On Linux, Chromium/Chrome must be at `/usr/bin/chromium-browser`
-      1. If this is too rigid, please [let us know](https://github.com/FundingCircle/fc4-framework/issues/new)
+
+MacOS quick-start for [Homebrew](https://brew.sh/) users: `brew cask install adoptopenjdk chromium`
+
 
 ### Download and Install
 

--- a/tool/bin/download-node-deps
+++ b/tool/bin/download-node-deps
@@ -2,8 +2,7 @@
 
 set -ex
 
-# We’re using the Chromium installed by APK as recommended here:
-#   https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-on-alpine
+# We’re using the system Chromium, for reasons.
 export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 # npm install automaticaly downloads deps if necessary

--- a/tool/renderer/package-lock.json
+++ b/tool/renderer/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "fc4-se-renderer",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@types/node": {
       "version": "8.10.36",
@@ -236,18 +235,18 @@
       "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4="
     },
     "puppeteer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.4.0.tgz",
-      "integrity": "sha512-WDnC1FSHTedvRSS8BZB73tPAx2svUCWFdcxVjrybw8pbKOAB1v5S/pW0EamkqQoL1mXiBc+v8lyYjhhzMHIk1Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.8.0.tgz",
+      "integrity": "sha512-wJ7Fxs03l4dy/ZXQACUKBBobIuJaS4NHq44q7/QinpAXFMwJMJFEIPjzoksVzUhZxQe+RXnjXH69mg13yMh0BA==",
       "requires": {
         "debug": "^3.1.0",
-        "extract-zip": "^1.6.5",
-        "https-proxy-agent": "^2.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^2.2.1",
         "mime": "^2.0.3",
         "progress": "^2.0.0",
         "proxy-from-env": "^1.0.0",
         "rimraf": "^2.6.1",
-        "ws": "^3.0.0"
+        "ws": "^5.1.1"
       }
     },
     "readable-stream": {
@@ -290,11 +289,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
-    "ultron": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -306,13 +300,11 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
-      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "async-limiter": "~1.0.0"
       }
     },
     "yauzl": {

--- a/tool/renderer/package.json
+++ b/tool/renderer/package.json
@@ -1,11 +1,10 @@
 {
   "name": "fc4-se-renderer",
-  "version": "1.0.0",
   "description": "Renders Structurizr Express diagrams in a headless browser using Puppeteer.",
   "main": "render.js",
   "dependencies": {
-    "data-uri-to-buffer": "^2.0.0",
-    "puppeteer": "^1.4.0"
+    "data-uri-to-buffer": "2.0.0",
+    "puppeteer": "1.8.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/tool/renderer/render.js
+++ b/tool/renderer/render.js
@@ -24,9 +24,10 @@ log.next = function(step) {
 function chromiumPath() {
   // TODO: accept a path as a command-line argument
   const possiblePaths = [
-    '/usr/bin/chromium-browser', // Alpine
     '/Applications/Chromium.app/Contents/MacOS/Chromium',
-    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'];
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/usr/bin/chromium', // Debian
+    '/usr/bin/chromium-browser']; // Alpine
 
   return possiblePaths.find(path => existsSync(path)) || null;
 }


### PR DESCRIPTION
This switches our test+build containers from Alpine to Debian Stretch,
which has a more recent version of Chromium. This allows us to upgrade
to a less ancient version of Puppeteer; this less ancient Puppeteer is
compatible with modern Chrome/Chromium. Therefore users no longer need
to have the ancient+obsolete Chrome/Chromium 68 installed on their
systems, which was unlikely, annoying, and insecure.

This also upgrades from Node 10 to Node 11, because why not 😬

Fixes #92