### PR TITLE
[priority: low] Publish distribution packages for all branch builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,11 +95,19 @@ jobs:
            name: Create GitHub Release and upload distribution packages to it
            # Docs for ghr’s options: https://github.com/tcnksm/ghr/#options
            command: |
-             TAG="${CIRCLE_BRANCH}_$(date "+%Y-%m-%d")_${CIRCLE_BUILD_NUM}"
+             if [[ $CIRCLE_BRANCH == "master" ]]; then
+               # Tag has build num suffix in case we do multiple releases on a given day.
+               TAG="release_$(date "+%Y-%m-%d")_${CIRCLE_BUILD_NUM}"
+             else
+               # We need this to be the same across all builds for a branch so we only ever keep the
+               # latest tag+release for a given branch, or we’d have way too many tags+branches.
+               TAG="prerelease_${CIRCLE_BRANCH}"
+             fi
              ~/bin/ghr -t $GITHUB_TOKEN \
                        -u $CIRCLE_PROJECT_USERNAME \
                        -r $CIRCLE_PROJECT_REPONAME \
                        -c $CIRCLE_SHA1 \
+                       $(if [[ ! $CIRCLE_BRANCH == "master" ]]; then echo -prerelease -recreate; fi) \
                        $TAG \
                        /workspace/packages
 
@@ -110,6 +118,4 @@ workflows:
       - tool_test
       - tool_clj_lint
       - tool_build_dist_pkg: {requires: [tool_test, tool_clj_lint]}
-      - tool_publish_dist_pkg:
-          requires: [tool_build_dist_pkg]
-          filters: {branches: {only: master}}
+      - tool_publish_dist_pkg: {requires: [tool_build_dist_pkg]}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
        - run:
            name: Download and unpack ghr
            command: |
-             if [ -f ~/bin/ghr ]; then exit 0; fi
+             if [ -x ~/bin/ghr ]; then exit 0; fi
              wget https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz
              tar -xzf ghr_v0.12.0_linux_amd64.tar.gz --strip-components 1 ghr_v0.12.0_linux_amd64/ghr
              mkdir -p ~/bin

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,23 +79,29 @@ jobs:
        - attach_workspace: {at: /workspace}
        - run: |
            [ "$GITHUB_TOKEN" ] || { echo 'GITHUB_TOKEN is not set!' && exit 1; }
+       - restore_cache: {keys: [ghr_v0.12.0_linux_amd64]}
        - run:
-           ## TODO: cache ghr
            name: Download and unpack ghr
            command: |
+             if [ -f ~/bin/ghr ]; then exit 0; fi
              wget https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz
              tar -xzf ghr_v0.12.0_linux_amd64.tar.gz --strip-components 1 ghr_v0.12.0_linux_amd64/ghr
+             mkdir -p ~/bin
+             mv ghr ~/bin/ghr
+       - save_cache:
+           key: ghr_v0.12.0_linux_amd64
+           paths: [~/bin]
        - run:
            name: Create GitHub Release and upload distribution packages to it
            # Docs for ghr’s options: https://github.com/tcnksm/ghr/#options
            command: |
              TAG="${CIRCLE_BRANCH}_$(date "+%Y-%m-%d")_${CIRCLE_BUILD_NUM}"
-             ./ghr -t $GITHUB_TOKEN \
-                   -u $CIRCLE_PROJECT_USERNAME \
-                   -r $CIRCLE_PROJECT_REPONAME \
-                   -c $CIRCLE_SHA1 \
-                   $TAG \
-                   /workspace/packages
+             ~/bin/ghr -t $GITHUB_TOKEN \
+                       -u $CIRCLE_PROJECT_USERNAME \
+                       -r $CIRCLE_PROJECT_REPONAME \
+                       -c $CIRCLE_SHA1 \
+                       $TAG \
+                       /workspace/packages
 
 workflows:
   version: 2


### PR DESCRIPTION
as prereleases.

This should be helpful for:

* Debugging — sometimes I need to use a built dist package to reproduce some problem so I can debug it
* Enabling users to try out features that are not 100% ready, so we can get feedback sooner rather than later
* Finding out about breakage in the publishing process sooner rather than later
  * If a commit/build breaks the publishing process somehow, this way we’ll find out