### PR TITLE
Refactor render namespaces

### DIFF
--- a/tool/src/cli/fc4/cli/render.clj
+++ b/tool/src/cli/fc4/cli/render.clj
@@ -1,69 +1,7 @@
 (ns fc4.cli.render
   "CLI subcommand that renders Structurizr Express diagrams into PNG image
   files."
-  (:require
-   [cognitect.anomalies  :as anom]
-   [clojure.java.io                             :as io :refer [file output-stream]]
-   [clojure.string                              :as str :refer [split]]
-   [fc4.cli.util                                :as cu :refer [debug]]
-   [fc4.integrations.structurizr.express.render :as r]))
-
-(defn fail
-  [file-path msg]
-  (cu/fail (str "Error rendering " file-path ": " msg)))
-
-(defn read-file
-  [path]
-  (try (slurp path)
-       (catch java.io.FileNotFoundException _ (fail path "file not found"))
-       (catch Exception e (fail path (.getMessage e)))))
-
-(defn validate
-  [yaml path]
-  (let [valid (r/valid? yaml)]
-    (when-not (true? valid)
-      (fail path (::anom/message valid)))))
-
-(defn render
-  [yaml path]
-  (println (str path "..."))
-  (let [result (r/render yaml)]
-    (debug (::r/stderr result))
-    result))
-
-(defn tmp-png-file
-  [path]
-  (-> (file path) (.getName)
-      (split #"\." 3) (first) ; remove “extension”
-      (java.io.File/createTempFile ".maybe.png")))
-
-(defn check
-  [result path]
-  (debug "checking result for errors...")
-  (condp #(contains? %2 %1) result
-    ::anom/message (fail path (::anom/message result))
-    ::r/png-bytes :all-good
-    (fail path (str "Internal error: render result invalid (has neither"
-                    " ::anom/message nor ::r/png-bytes)")))
-
-  (debug "checking PNG data size...")
-  (when (< (count (::r/png-bytes result))
-           ; arbitrary number is arbitrary. That said, according to my gut, less
-           ; data is likely to be invalid, and more has a chance of being valid.
-           1024)
-    (let [tmpfile (tmp-png-file path)]
-      (with-open [out (output-stream tmpfile)]
-        (.write out (::r/png-bytes result)))
-      (fail path (str "PNG data is <1K so it’s likely invalid. It’s been"
-                      " written to " tmpfile " for debugging."))))
-
-  (debug "rendering seems to have succeeded!"))
-
-(defn get-out
-  [in-path]
-  (-> (str/replace in-path #"\.ya?ml$" ".png")
-      (file)
-      (output-stream)))
+  (:require [fc4.io.render :refer [render-diagram-file]]))
 
 (defn -main
   ;; NB: if and when we add options we’ll probably want to use
@@ -75,10 +13,4 @@
   ;; TODO: add a command-line flag that sets cu/*debug* to true
   [& paths]
   (doseq [path paths]
-    (let [yaml                               (read-file path)
-          _                                  (validate yaml path)
-          result                             (render yaml path)
-          _                                  (check result path)
-          {:keys [::r/png-bytes ::r/stderr]} result]
-      (with-open [out (get-out path)]
-        (.write out png-bytes)))))
+    (render-diagram-file path)))

--- a/tool/src/cli/fc4/cli/render.clj
+++ b/tool/src/cli/fc4/cli/render.clj
@@ -1,7 +1,8 @@
 (ns fc4.cli.render
   "CLI subcommand that renders Structurizr Express diagrams into PNG image
   files."
-  (:require [fc4.io.render :refer [render-diagram-file]]))
+  (:require [fc4.cli.util :as cu :refer [debug fail]]
+            [fc4.io.render :refer [render-diagram-file]]))
 
 (defn -main
   ;; NB: if and when we add options we’ll probably want to use
@@ -12,5 +13,12 @@
   ;;
   ;; TODO: add a command-line flag that sets cu/*debug* to true
   [& paths]
-  (doseq [path paths]
-    (render-diagram-file path)))
+  (try
+    (doseq [path paths]
+      (print (str path "..."))
+      (flush)
+      (render-diagram-file path)
+      (println "✅"))
+    (catch Exception e
+      ; TODO: maybe use cu/debug print out stack trace and ex-data if present?
+      (fail (.getMessage e)))))

--- a/tool/src/main/fc4/integrations/structurizr/express/render.clj
+++ b/tool/src/main/fc4/integrations/structurizr/express/render.clj
@@ -128,7 +128,7 @@
          ::stderr        err
          ::error         error}))))
 
-(s/def ::png-bytes bytes?)
+(s/def ::png-bytes (s/and bytes? #(> (count %) 0)))
 (s/def ::result (s/keys :req [::png-bytes ::stderr]))
 
 (s/def ::failure

--- a/tool/src/main/fc4/integrations/structurizr/express/render.clj
+++ b/tool/src/main/fc4/integrations/structurizr/express/render.clj
@@ -143,7 +143,7 @@
                     :failure ::failure))
 
 (comment
-  (use 'clojure.java.io 'clojure.java.shell)
+  (use 'clojure.java.io 'clojure.java.shell 'fc4.io)
   (require :reload '[fc4.integrations.structurizr.express.render :as r])
   (in-ns 'fc4.integrations.structurizr.express.render)
 
@@ -155,9 +155,5 @@
   (def pngb (or (::png-bytes result)
                 (::anom/message result)
                 "WTF"))
-
-  (defn binary-spit [file-path data]
-    (with-open [out (output-stream (file file-path))]
-      (.write out data)))
 
   (binary-spit "/tmp/diagram.png" pngb))

--- a/tool/src/main/fc4/io.clj
+++ b/tool/src/main/fc4/io.clj
@@ -139,6 +139,15 @@
         :ret  (s/or :success ::st/styles
                     :error   ::error))
 
+(defn binary-slurp
+  "fp should be either a java.io.File or something coercable to such by
+  clojure.java.io/file."
+  [fp]
+  (let [f (file fp)]
+    (with-open [out (java.io.ByteArrayOutputStream. (.length f))]
+      (copy f out)
+      (.toByteArray out))))
+
 (defn binary-spit
   "fp must be a java.io.File or something coercable to such via
   clojure.java.io/file"

--- a/tool/src/main/fc4/io.clj
+++ b/tool/src/main/fc4/io.clj
@@ -2,7 +2,7 @@
   "Provides all I/O facilities so that the other namespaces can be pure. The
   function specs are provided as a form of documentation and for instrumentation
   during development. They should not be used for generative testing."
-  (:require [clojure.java.io         :as io]
+  (:require [clojure.java.io         :as io :refer [copy file output-stream]]
             [clojure.spec.alpha      :as s]
             [clojure.spec.gen.alpha  :as gen]
             [clojure.string          :as str :refer [ends-with?]]
@@ -133,3 +133,10 @@
         :args (s/cat :file-path ::fs/file-path-str)
         :ret  (s/or :success ::st/styles
                     :error   ::error))
+
+(defn binary-spit
+  "fp must be a java.io.File or something coercable to such via
+  clojure.java.io/file"
+  [fp data]
+  (with-open [out (output-stream (file fp))]
+    (copy data out)))

--- a/tool/src/main/fc4/io.clj
+++ b/tool/src/main/fc4/io.clj
@@ -17,14 +17,19 @@
             [fc4.view               :as v :refer [view-from-file]])
   (:import [java.io FileNotFoundException]))
 
+(defn yaml-file?
+  [f]
+  (and (.isFile (file f))
+       (or (ends-with? f ".yaml")
+           (ends-with? f ".yml"))))
+
 (defn yaml-files
   "Accepts a directory as a path string or a java.io.File, returns a lazy sequence of java.io.File objects for
   all the YAML files in that dir or in any of its child dirs (recursively) to an unlimited depth."
   [dir]
   (->> (io/file dir)
-       file-seq
-       (filter #(or (ends-with? % ".yaml")
-                    (ends-with? % ".yml")))))
+       (file-seq)
+       (filter yaml-file?)))
 
 (s/fdef yaml-files
         :args (s/cat :dir ::fs/dir-path)

--- a/tool/src/main/fc4/io/render.clj
+++ b/tool/src/main/fc4/io/render.clj
@@ -1,0 +1,76 @@
+(ns fc4.io.render
+  "Functions for rendering Structurizr Express diagrams into PNG image files.
+  NB: because these functions are specifically intended for implementing CLI
+  commands, some of them write to stdout/stderr and may call fc4.cli.util/fail
+  (which calls System/exit unless fc4.cli.util/*exit-on-fail* is rebound)."
+  (:require [cognitect.anomalies :as anom]
+            [clojure.java.io :as io :refer [file output-stream]]
+            [clojure.string :as str :refer [split]]
+            [fc4.cli.util :as cu :refer [debug]]
+            [fc4.io :refer [binary-spit]]
+            [fc4.integrations.structurizr.express.render :as r])
+  (:import [java.io FileNotFoundException]))
+
+(defn fail
+  [file-path msg]
+  (cu/fail (str "Error rendering " file-path ": " msg)))
+
+(defn read-text-file
+  [path]
+  (try (slurp path)
+       (catch FileNotFoundException _ (fail path "file not found"))
+       (catch Exception e (fail path (.getMessage e)))))
+
+(defn validate
+  [yaml path]
+  (let [valid (r/valid? yaml)]
+    (when-not (true? valid)
+      (fail path (::anom/message valid)))))
+
+(defn render
+  [yaml path]
+  (println (str path "..."))
+  (let [result (r/render yaml)]
+    (debug (::r/stderr result))
+    result))
+
+(defn tmp-png-file
+  [path]
+  (-> (file path) (.getName)
+      (split #"\." 3) (first) ; remove “extension”
+      (java.io.File/createTempFile ".maybe.png")))
+
+(defn check
+  [result path]
+  (debug "checking result for errors...")
+  (condp #(contains? %2 %1) result
+    ::anom/message (fail path (::anom/message result))
+    ::r/png-bytes :all-good
+    (fail path (str "Internal error: render result invalid (has neither"
+                    " ::anom/message nor ::r/png-bytes)")))
+
+  (debug "checking PNG data size...")
+  (when (< (count (::r/png-bytes result))
+           ; arbitrary number is arbitrary. That said, according to my gut, less
+           ; data is likely to be invalid, and more has a chance of being valid.
+           1024)
+    (let [tmpfile (tmp-png-file path)]
+      (with-open [out (output-stream tmpfile)]
+        (.write out (::r/png-bytes result)))
+      (fail path (str "PNG data is <1K so it’s likely invalid. It’s been"
+                      " written to " tmpfile " for debugging."))))
+
+  (debug "rendering seems to have succeeded!"))
+
+(defn get-out
+  [in-path]
+  (str/replace in-path #"\.ya?ml$" ".png"))
+
+(defn render-diagram-file
+  [in-path]
+  (let [yaml     (read-text-file in-path)
+        _        (validate yaml in-path)
+        result   (render yaml in-path)
+        _        (check result in-path)
+        out-path (get-out in-path)]
+    (binary-spit out-path (::r/png-bytes result))))

--- a/tool/src/main/fc4/io/render.clj
+++ b/tool/src/main/fc4/io/render.clj
@@ -5,10 +5,12 @@
   (which calls System/exit unless fc4.cli.util/*exit-on-fail* is rebound)."
   (:require [cognitect.anomalies :as anom]
             [clojure.java.io :as io :refer [file output-stream]]
-            [clojure.string :as str :refer [split]]
+            [clojure.spec.alpha :as s]
+            [clojure.string :as str :refer [ends-with? includes? split]]
             [fc4.io :refer [binary-spit]]
-            [fc4.integrations.structurizr.express.render :as r])
-  (:import [java.io FileNotFoundException]))
+            [fc4.integrations.structurizr.express.render :as r]
+            [fc4.spec :as fs])
+  (:import [java.io File FileNotFoundException]))
 
 ; Feel free to change for development or whatever.
 ; This is an atom rather than a dynamic var because the functions in this
@@ -23,7 +25,18 @@
 
 (defn err-msg
   [file-path msg]
-  (str "Error rendering " file-path ": " msg))
+  (str "Error rendering [" file-path "]: " msg))
+
+(s/fdef err-msg
+        :args (s/cat :file ::fs/non-blank-str
+                     :msg  ::fs/non-blank-str)
+        :ret  ::fs/non-blank-str
+        :fn   (fn [{:keys [args ret]}]
+                (every? (partial includes? ret)
+                        (vals args))))
+
+; rebind for testing
+(def ^:dynamic *throw-on-fail* true)
 
 (defn fail
   ([path msg]
@@ -31,9 +44,10 @@
   ([path msg data]
    (fail path msg data nil))
   ([path msg data cause]
-   (throw (if cause
-            (ex-info (err-msg path msg) data cause)
-            (ex-info (err-msg path msg) data)))))
+   (let [e (if cause
+             (ex-info (err-msg path msg) data cause)
+             (ex-info (err-msg path msg) data))]
+     (if *throw-on-fail* (throw e) e))))
 
 (defn read-text-file
   [path]
@@ -43,15 +57,20 @@
 
 (defn validate
   [yaml path]
-  (let [valid (r/valid? yaml)]
-    (when-not (true? valid)
-      (fail path (::anom/message valid)))))
+  (let [result (r/valid? yaml)]
+    (when-not (true? result)
+      (fail path (::anom/message result)))))
 
-(defn render
-  [yaml path]
-  (let [result (r/render yaml)]
-    (debug (::r/stderr result))
-    result))
+(s/fdef validate
+        :args (s/cat :yaml (s/or :valid :structurizr/diagram-yaml-str
+                                 :invalid string?)
+                     :path ::fs/non-blank-simple-str)
+        :ret  (s/or :valid   nil?
+                    :invalid (partial instance? Exception))
+        :fn   (fn [{{:keys [yaml path]} :args, ret :ret}]
+                (and (= (first yaml) (first ret))
+                     (or (= (first yaml) :valid)
+                         (includes? (.getMessage (second ret)) path)))))
 
 (defn tmp-png-file
   [path]
@@ -59,27 +78,75 @@
       (split #"\." 3) (first) ; remove “extension”
       (java.io.File/createTempFile ".maybe.png")))
 
+(s/fdef tmp-png-file
+        :args (s/cat :path (s/and ::fs/file-path-str
+                                  #(>= (count (.getName (file %))) 3)))
+        :ret  (s/and (partial instance? File)
+                     #(.canWrite %)
+                     #(ends-with? % ".maybe.png"))
+        :fn   (fn [{:keys [args ret]}]
+                (includes? (str ret) (-> (:path args)
+                                         (file)
+                                         (.getName)
+                                         (split #"\." 3)
+                                         (first)))))
+
+; Arbitrary number is arbitrary. That said, according to my gut, less
+; data is likely to be invalid, and more has a chance of being valid.
+(def min-valid-png-size 1024)
+
 (defn check
   [result path]
   (debug "checking result for errors...")
-  (condp #(contains? %2 %1) result
-    ::anom/message (fail path (::anom/message result))
-    ::r/png-bytes :all-good
-    (fail path (str "Internal error: render result invalid (has neither"
-                    " ::anom/message nor ::r/png-bytes)")))
 
-  (debug "checking PNG data size...")
-  (when (< (count (::r/png-bytes result))
-           ; arbitrary number is arbitrary. That said, according to my gut, less
-           ; data is likely to be invalid, and more has a chance of being valid.
-           1024)
-    (let [tmpfile (tmp-png-file path)]
-      (with-open [out (output-stream tmpfile)]
-        (.write out (::r/png-bytes result)))
-      (fail path (str "PNG data is <1K so it’s likely invalid. It’s been"
-                      " written to " tmpfile " for debugging."))))
+  ;; In dev/test fail will return an exception rather than throw it, so we use
+  ;; or here to ensure the function exits when a failure condition is
+  ;; encountered, because we can’t count on fail throwing and thus forcing the
+  ;; function to exit at that point.
+  (or
+   (condp #(contains? %2 %1) result
+     ::anom/message (fail path (::anom/message result))
+     ::r/png-bytes nil
+     (fail path (str "Internal error: render result invalid (has neither"
+                     " ::anom/message nor ::r/png-bytes)")))
 
-  (debug "rendering seems to have succeeded!"))
+   (debug "checking PNG data size...")
+
+   (when (< (count (::r/png-bytes result)) min-valid-png-size)
+     (let [tmpfile (tmp-png-file path)]
+       (with-open [out (output-stream tmpfile)]
+         (.write out (::r/png-bytes result)))
+       (fail path (str "PNG data is <1K so it’s likely invalid. It’s been"
+                       " written to " tmpfile " for debugging."))))
+
+   (debug "rendering seems to have succeeded!")
+   nil))
+
+(s/fdef check
+        :args (s/cat :result (s/or :success ::r/result
+                                   :failure ::r/failure)
+                     :path   ::fs/file-path-str)
+        :ret  (s/or :success nil?
+                    :failure (partial instance? Exception))
+        :fn   (fn [{{[result-tag result-val] :result
+                     path                    :path}  :args
+                    [ret-tag ret-val]                :ret}]
+                (case result-tag
+                  :failure
+                  (and (= ret-tag :failure)
+                       (includes? (.getMessage ret-val) path))
+
+                  ; this case can still fail the check if png-bytes is too small
+                  :success
+                  (cond
+                    (>= (count (::r/png-bytes result-val)) min-valid-png-size)
+                    (= ret-tag :success)
+
+                    (< (count (::r/png-bytes result-val)) min-valid-png-size)
+                    (and (= ret-tag :failure)
+                         (includes? (.getMessage ret-val) path)))
+
+                  false)))
 
 (defn get-out
   [in-path]
@@ -93,7 +160,8 @@
   [in-path]
   (let [yaml     (read-text-file in-path)
         _        (validate yaml in-path)
-        result   (render yaml in-path)
+        result   (r/render yaml)
+        _        (debug (::r/stderr result))
         _        (check result in-path)
         out-path (get-out in-path)]
     (binary-spit out-path (::r/png-bytes result))

--- a/tool/src/main/fc4/spec.clj
+++ b/tool/src/main/fc4/spec.clj
@@ -49,7 +49,8 @@
     (s/and ::non-blank-simple-str #(includes? % "/"))
     #(gen/fmap
       (fn [s] (str (->> (repeat 5 s) (join "/"))))
-      (s/gen ::short-non-blank-simple-str))))
+      (s/gen (s/and ::short-non-blank-simple-str
+                    (fn [s] (>= (count s) 3)))))))
 
 (s/def ::file-path-file
   (s/with-gen

--- a/tool/test/fc4/integrations/structurizr/express/render_test.clj
+++ b/tool/test/fc4/integrations/structurizr/express/render_test.clj
@@ -1,5 +1,6 @@
 (ns fc4.integrations.structurizr.express.render-test
   (:require [fc4.integrations.structurizr.express.render :as r]
+            [fc4.io :refer [binary-spit binary-slurp]]
             [fc4.test-utils :refer [check]]
             [fc4.test-utils.image-diff :refer [bytes->buffered-image image-diff]]
             [clojure.java.io :refer [copy file input-stream output-stream]]
@@ -27,22 +28,6 @@
 (do
   (System/setProperty "apple.awt.UIElement" "true")
   (require '[image-resizer.core :refer [resize]]))
-
-(defn binary-slurp
-  "fp should be either a java.io.File or something coercable to such by
-  clojure.java.io/file."
-  [fp]
-  (let [f (file fp)]
-    (with-open [out (java.io.ByteArrayOutputStream. (.length f))]
-      (copy f out)
-      (.toByteArray out))))
-
-(defn binary-spit
-  "fp should be either a java.io.File or something coercable to such by
-  clojure.java.io/file."
-  [fp data]
-  (with-open [out (output-stream (file fp))]
-    (copy data out)))
 
 (def max-allowable-image-difference
   ;; This threshold might seem low, but the diffing algorithm is

--- a/tool/test/fc4/io/render_test.clj
+++ b/tool/test/fc4/io/render_test.clj
@@ -1,18 +1,41 @@
 (ns fc4.io.render-test
-  (:require [clojure.spec.alpha   :as s]
-            [clojure.string :as str :refer [includes?]]
+  (:require [clojure.java.io      :as jio :refer [file]]
+            [clojure.spec.alpha   :as s]
+            [clojure.string       :as str :refer [includes?]]
             [clojure.test         :as ct :refer [deftest is testing]]
             [cognitect.anomalies  :as anom]
-            [fc4.io               :as io]
+            [fc4.io               :as io :refer [binary-slurp]]
             [fc4.io.render        :as r]
-            [fc4.test-utils       :as tu :refer [check]])
+            [fc4.test-utils       :as tu :refer [check]]
+            [fc4.test-utils.image-diff :refer [bytes->buffered-image image-diff]])
   (:import [java.io FileNotFoundException]))
+
+; Require image-resizer.core while preventing the Java app icon from popping up
+; and grabbing focus on MacOS.
+; Approach found here: https://stackoverflow.com/questions/17460777/stop-java-coffee-cup-icon-from-appearing-in-the-dock-on-mac-osx/17544259#comment48475681_17544259
+; This require is here rather than in the ns form at the top of the file because
+; if I include this ns in the require list in the ns form, then the only way to
+; suppress the app icon from popping up and grabbing focus would be to place the
+; System/setProperty call at the top of the file, before the ns form, and that’d
+; violate Clojure idioms. When people open a clj file, they expect to see a ns
+; form right at the top declaring which namespace the file defines and
+; populates.
+; To be clear, calling the `require` function in a clj file, to require a
+; dependency, outside of the ns form, is *also* non-idiomatic; people expect all
+; of the dependencies of a file to be listed in the ns form. So I had to choose
+; between two non-idiomatic solutions; I chose this one because it seems to me
+; to be slightly less jarring for Clojurists.
+(do
+  (System/setProperty "apple.awt.UIElement" "true")
+  (require '[image-resizer.core :refer [resize]]))
+
+(reset! r/debug? true)
 
 (deftest err-msg (check `r/err-msg))
 
 (deftest read-text-file
   (let [existant     "test/data/styles (valid).yaml"
-        non-existant "test/data/does not exist"
+        non-existant "test/data/does_not_exist"
         not-text     "test/data/structurizr/express/diagram_valid_cleaned_expected.png"]
     (is (includes? (r/read-text-file existant) "The FC4 Framework"))
     (is (thrown-with-msg? Exception #"file not found" (r/read-text-file non-existant)))
@@ -30,3 +53,46 @@
 (deftest check-fn
   (binding [r/*throw-on-fail* false]
     (check `r/check)))
+
+(def max-allowable-image-difference
+  ;; This threshold might seem low, but the diffing algorithm is
+  ;; giving very low results for some reason. This threshold seems
+  ;; to be sufficient to make the random watermark effectively ignored
+  ;; while other, more significant changes (to my eye) seem to be
+  ;; caught. Still, this is pretty unscientific, so it might be worth
+  ;; looking into making this more precise and methodical.
+  0.005)
+
+(deftest render-diagram-file
+  (let [valid        "test/data/structurizr/express/diagram_valid_cleaned.yaml"
+        invalid_a    "test/data/structurizr/express/se_diagram_invalid_a.yaml"
+        invalid_b    "test/data/structurizr/express/se_diagram_invalid_b.yaml"
+        non-existant "test/data/does_not_exist"
+        not-text     "test/data/structurizr/express/diagram_valid_cleaned_expected.png"]
+    (testing "a YAML file containing a valid SE diagram"
+      (let [expected-out-path (r/get-out valid)
+            expected-bytes (binary-slurp not-text)
+            result (r/render-diagram-file valid)]
+        (is (= result expected-out-path))
+        (is (.canRead (file result)))
+        (let [actual-bytes (binary-slurp result)
+              difference (->> [actual-bytes expected-bytes]
+                              (map bytes->buffered-image)
+                              (map #(resize % 1000 1000))
+                              (reduce image-diff))]
+          (is (<= difference max-allowable-image-difference)))))
+    (testing "a YAML file containing a blatantly invalid SE diagram"
+      (is (thrown-with-msg? Exception
+                            #"invalid because it is missing the root property"
+                            (r/render-diagram-file invalid_a))))
+    (testing "a YAML file containing a subtly invalid SE diagram"
+      (is (thrown-with-msg? Exception
+                            #"(?s)Errors were found in the diagram definition.+diagram type"
+                            (r/render-diagram-file invalid_b))))
+    (testing "a input file path that does not exist"
+      (is (thrown-with-msg? Exception #"exist" (r/render-diagram-file non-existant))))
+    (testing "a input file that does not contain text"
+      (is (thrown-with-msg?
+           Exception
+           #"Error rendering.+cursory check.+not a valid Structurizr Express diagram definition"
+           (r/render-diagram-file not-text))))))

--- a/tool/test/fc4/io/render_test.clj
+++ b/tool/test/fc4/io/render_test.clj
@@ -70,7 +70,7 @@
         non-existant "test/data/does_not_exist"
         not-text     "test/data/structurizr/express/diagram_valid_cleaned_expected.png"]
     (testing "a YAML file containing a valid SE diagram"
-      (let [expected-out-path (r/get-out valid)
+      (let [expected-out-path (r/yaml-path->png-path valid)
             expected-bytes (binary-slurp not-text)
             result (r/render-diagram-file valid)]
         (is (= result expected-out-path))

--- a/tool/test/fc4/io/render_test.clj
+++ b/tool/test/fc4/io/render_test.clj
@@ -1,0 +1,32 @@
+(ns fc4.io.render-test
+  (:require [clojure.spec.alpha   :as s]
+            [clojure.string :as str :refer [includes?]]
+            [clojure.test         :as ct :refer [deftest is testing]]
+            [cognitect.anomalies  :as anom]
+            [fc4.io               :as io]
+            [fc4.io.render        :as r]
+            [fc4.test-utils       :as tu :refer [check]])
+  (:import [java.io FileNotFoundException]))
+
+(deftest err-msg (check `r/err-msg))
+
+(deftest read-text-file
+  (let [existant     "test/data/styles (valid).yaml"
+        non-existant "test/data/does not exist"
+        not-text     "test/data/structurizr/express/diagram_valid_cleaned_expected.png"]
+    (is (includes? (r/read-text-file existant) "The FC4 Framework"))
+    (is (thrown-with-msg? Exception #"file not found" (r/read-text-file non-existant)))
+    ; read-text-file is a thin wrapper for slurp; as such it behaves the same as
+    ; slurp when passed the path to a non-text file: reads the contents of the file
+    ; as a String and returns that String. The String is non-sensical but so be it.
+    (is (string? (r/read-text-file not-text)))))
+
+(deftest validate
+  (binding [r/*throw-on-fail* false]
+    (check `r/validate)))
+
+(deftest tmp-png-file (check `r/tmp-png-file))
+
+(deftest check-fn
+  (binding [r/*throw-on-fail* false]
+    (check `r/check)))


### PR DESCRIPTION
Main goal here was to move most functions from `fc4.cli.render` to `fc4.io.render`.

This is preparatory refactoring for EP05 (#111) for which we’ll soon be adding a new `edit` CLI command that will be implemented in `fc4.cli.edit` and will also need to render YAML files. In other words, the functionality that until now was only in fc4.cli.render will need to be used by two different namespaces under fc4.cli, so we needed that functionality to be in a third namespace. (I’m writing in the future tense because that’s what makes sense in the context of this PR but I’ve actually already implemented `fc4.cli.edit` in a “child” branch.)

I chose to move these functions out of the `cli` source tree and into the `main` source tree because by convention we don’t have tests for the code under `cli` but we do have tests for that under `main`. And since this code will now be shared by more than one ns, and anyway since it was fairly extensive, it should be tested.

I recommend reviewing each commit individually.

Thank you!