### PR TITLE
[docs] Convert Markdown inside table to HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,22 @@ inline CSS. Understandable. So while this is kinda ugly, it more or less works. 
 
 <table><tr><td>
 
-FC4 is a [_Docs as Code_](https://www.writethedocs.org/guide/docs-as-code/) framework that enables software creators to author, publish, and maintain software architecture diagrams more effectively, efficiently, and collaboratively over time.
+FC4 is a <a href="https://www.writethedocs.org/guide/docs-as-code/"><i>Docs as Code</i></a>
+framework that enables software creators to author, publish, and maintain software architecture
+diagrams more effectively, efficiently, and collaboratively over time.
 
 It has two components:
 
-* [the methodology](methodology/)
-* [fc4-tool](tool/)
+<ul>
+  <li><a href="methodology/">the methodology</a>
+  <li><a href="tool/">the tool</a>
+</ul>
 
 </td><td>
 
 <img src="https://fundingcircle.github.io/fc4-framework/tool/doc/fc4-tool-container.png"
-     width="800"
-     height="213"
+     width="60%"
+     height="60%"
      alt="Example: a container diagram of fc4-tool."
      title="Example: a container diagram of fc4-tool.">
 


### PR DESCRIPTION
This is a follow-up to #142. I used [grip][grip] to preview the markup wherein Markdown was nested
inside HTML, and it rendered just fine. So that situation renders just
fine within github.com, e.g. when viewing the repo or the readme. I had
thought that GitHub Pages used the same Markdown renderer as github.com,
but apparently not — when this was published to [the main FC4 website][home]
the Markdown markup was escaped, not rendered.

Converting the content in the table to HTML should eliminate this problem.
It’s maybe not super-ideal, but table support in Markdown is iffy in
general, so I can live with this. I think it’s an acceptable situation
until we switch the main website to a custom Jekyll theme and I can
start using CSS to lay out the page rather than tables.

[grip]: https://github.com/joeyespo/grip
[home]: https://fundingcircle.github.io/fc4-framework/

<img width="770" alt="screen shot 2019-02-12 at 12 35 54" src="https://user-images.githubusercontent.com/141844/52655694-c5e28280-2ec2-11e9-87a1-b5d247110ef2.png">
