### PR TITLE
[docs] HTML fixes for Jekyll compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,28 +4,41 @@
 style on the img tag (or a wrapping figure tag) — but no dice. It looks like GitHub Pages strips
 inline CSS. Understandable. So while this is kinda ugly, it more or less works. -->
 
-<table><tr><td>
+<!-- Using inline CSS in the style attribute rather than a style tag or a css file because while
+GitHub Pages (Jekyll) supports a style tag, github.com does not; this file is viewed and rendered in
+both contexts. This will all get cleaned up when we decouple the two use cases (I plan to move the
+GitHub Pages website into a subdirectory in the repo named “docs” after which the markup in its
+files will only need to be compatible with a single Markdown processor (Jekyll) rather than two.) -->
 
-FC4 is a <a href="https://www.writethedocs.org/guide/docs-as-code/"><i>Docs as Code</i></a>
-framework that enables software creators to author, publish, and maintain software architecture
-diagrams more effectively, efficiently, and collaboratively over time.
+<table style="border:none;">
+<tr style="border:none;">
+<td style="border:none; padding:0;">
+
+<!-- Using HTML inside the table cells, rather than Markdown, because the Markdown processor used
+for GitHub pages (via Jekyll) apparently won’t process Markdown nested inside HTML tags. -->
+
+<p>FC4 is a <a href="https://www.writethedocs.org/guide/docs-as-code/"><i>Docs as Code</i></a>
+   framework that enables software creators to author, publish, and maintain software architecture
+   diagrams more effectively, efficiently, and collaboratively over time.</p>
 
 It has two components:
 
 <ul>
-  <li><a href="methodology/">the methodology</a>
-  <li><a href="tool/">the tool</a>
+  <li><a href="methodology/">the methodology</a></li>
+  <li><a href="tool/">the tool</a></li>
 </ul>
 
-</td><td>
+</td>
+<td width="350" style="border:none; padding:0;">
 
 <img src="https://fundingcircle.github.io/fc4-framework/tool/doc/fc4-tool-container.png"
-     width="60%"
-     height="60%"
+     width="350" height="248"
      alt="Example: a container diagram of fc4-tool."
      title="Example: a container diagram of fc4-tool.">
 
-</td></tr></table>
+</td>
+</tr>
+</table>
 
 It builds on [the C4 Model](https://c4model.com/) and [Structurizr Express](https://structurizr.com/express), both of which were created by and are maintained by [Simon Brown](http://simonbrown.je/).
 


### PR DESCRIPTION
This is a follow-up to #143, as per [this comment](
https://github.com/FundingCircle/fc4-framework/pull/143#issuecomment-462864842):

> Huh, it didn’t work:
> 
> <img alt="screen shot 2019-02-12 at 12 53 52" width="962" src="https://user-images.githubusercontent.com/141844/52656877-4bffc880-2ec5-11e9-985c-c02bbab9cf16.png">
> 
> My mistake for being lazy and not using jekyll to preview locally. I’ll do that now and try another fix.

Apparently for whatever reason Jekyll doesn’t like HTML table tags to be
stacked successively in the same line. Whatever.