### PR TITLE
Add Clojure Renderer

### DIFF
--- a/tool/deps.edn
+++ b/tool/deps.edn
@@ -1,8 +1,19 @@
 {:paths ["src/main" "src/cli"]
+
+ ;; It may seem redundant to include this key with the value being the same as the usual default
+ ;; (as set in the “installation” deps.edn — the one that lives with Clojure’s files). This is
+ ;; indeed included here for a somewhat esoteric reason: because Cambada, which is used to build the
+ ;; “überjar” for this tool (see the :uberjar alias below) can’t access the installation deps.edn
+ ;; and doesn’t want to make assumptions for us. For more info see:
+ ;;   https://github.com/luchiniatwork/cambada/issues/19#issuecomment-490013695
+ :mvn/repos {"central" {:url "http://central.maven.org/maven2/"}
+             "clojars" {:url "https://repo.clojars.org/"}}
+
  :deps
  {org.clojure/clojure         {:mvn/version "1.10.0"}
   org.clojure/spec.alpha      {:mvn/version "0.2.176"}
   org.clojure/tools.cli       {:mvn/version "0.4.1"}
+  clj-chrome-devtools         {:mvn/version "20190502"}
   clj-commons/clj-yaml        {:mvn/version "0.6.1"}
   expound                     {:mvn/version "0.7.2"}
   com.cognitect/anomalies     {:mvn/version "0.1.12"}
@@ -14,7 +25,7 @@
   ;; to fail. I’m overriding the dependency here at the root level, which takes precedence over the
   ;; profiles, because I want to ensure that we’ll use the same version of joda-time when running
   ;; the tests and building a distribution package (uberjar).
-  joda-time/joda-time         {:mvn/version "2.10.1"}
+  joda-time/joda-time {:mvn/version "2.10.1"}
 
   ;; Conflicting versions of jna are resolved via org.clojure/tools.gitlibs and hawk.
   net.java.dev.jna/jna          {:mvn/version "5.2.0"}
@@ -24,15 +35,17 @@
   ;; because we’re using one of its generators in a spec in a source file.
   ;; This means we’ll also need org.clojure/test.check at runtime. Not ideal,
   ;; but worth it.
-  com.gfredericks/test.chuck  {:mvn/version "0.2.9"}}
+  com.gfredericks/test.chuck {:mvn/version "0.2.9"}}
 
  :aliases {:dev           {:extra-deps  {org.clojure/tools.trace    {:mvn/version "0.7.9"}
                                          inspectable                {:mvn/version "0.2.2"}}
-                           :jvm-opts    ["-XX:-OmitStackTraceInFastThrow"]}
+                           :jvm-opts    ["-XX:-OmitStackTraceInFastThrow"
+                                         "--illegal-access=warn"]}
 
            :test          {:extra-paths ["test" "src/test_utils"]
                            :extra-deps  {org.clojure/test.check     {:mvn/version "0.10.0-alpha3"}
                                          eftest                     {:mvn/version "0.5.4"}
+                                         orchestra                  {:mvn/version "2018.12.06-2"}
                                          image-resizer              {:mvn/version "0.1.10"}}
                            ; It’s crucial to ensure that the JVM’s default character encoding is
                            ; UTF-8 because the renderer outputs UTF-8 encoded text to its stderr,

--- a/tool/src/main/fc4/image_utils.clj
+++ b/tool/src/main/fc4/image_utils.clj
@@ -1,0 +1,46 @@
+(ns fc4.image-utils
+  (:require [clojure.string :refer [starts-with?]])
+  (:import [java.io ByteArrayInputStream ByteArrayOutputStream]
+           [java.util Base64]
+           [javax.imageio ImageIO]))
+
+;; Some of the functions include some type hints or type casts. These are to prevent reflection, but
+;; not for the usual reason of improving performance. In this case, some of the reflection leads to
+;; classes that violate some kind of boundary introduced in Java 9/10/11 and yield an ominous
+;; message printed to stdout (or maybe stderr).
+
+;; Import various Java AWT classes that we need to work with the images — but first set a system
+;; property that will prevent the Java app icon from popping up and grabbing focus on MacOS. That is
+;; why these imports are here rather that in the ns form.
+(System/setProperty "apple.awt.UIElement" "true")
+(import '[java.awt Image]
+        '[java.awt.image BufferedImage])
+
+(defn bytes->buffered-image ^BufferedImage [bytes]
+  (ImageIO/read (ByteArrayInputStream. bytes)))
+
+(defn buffered-image->bytes
+  [^BufferedImage img]
+  (let [baos (ByteArrayOutputStream.)]
+    (ImageIO/write img "png" baos)
+    (.toByteArray baos)))
+
+(def ^:private png-data-uri-prefix "data:image/png;base64,")
+
+(defn png-data-uri->bytes
+  [data-uri]
+  {:pre [(string? data-uri)
+         (starts-with? data-uri png-data-uri-prefix)]}
+  (let [decoder (Base64/getDecoder)]
+    (->> (subs data-uri (count png-data-uri-prefix))
+         (.decode decoder))))
+
+(defn width
+  "Get the width of a java.awt.Image concisely and without reflection."
+  [^Image image]
+  (.getWidth image nil))
+
+(defn height
+  "Get the height of a java.awt.Image concisely and without reflection."
+  [^Image image]
+  (.getHeight image nil))

--- a/tool/src/main/fc4/integrations/structurizr/express/chromium_renderer.clj
+++ b/tool/src/main/fc4/integrations/structurizr/express/chromium_renderer.clj
@@ -193,7 +193,7 @@
   ;; Protect developers from themselves
   {:pre [(not (ends-with? diagram-yaml ".yaml")) (not (ends-with? diagram-yaml ".yml"))]}
   ;; TODO: LOTS more error handling!
-  (load-structurizr-express automation structurizr-express-url)
+  (load-structurizr-express automation structurizr-express-url) ;; TODO: Check return value!
   (if-let [err-msg (set-yaml-and-update-diagram automation (prep-yaml diagram-yaml))]
     (fault err-msg)
     (let [diagram-image (extract-diagram automation)

--- a/tool/src/main/fc4/integrations/structurizr/express/chromium_renderer.clj
+++ b/tool/src/main/fc4/integrations/structurizr/express/chromium_renderer.clj
@@ -1,0 +1,280 @@
+(ns fc4.integrations.structurizr.express.chromium-renderer
+  (:require [clj-chrome-devtools.automation :as a :refer [automation?]]
+            [clj-chrome-devtools.core :as chrome]
+            [clj-chrome-devtools.impl.connection :refer [connection?]]
+            [clojure.java.io :refer [file]]
+            [clojure.spec.alpha :as s]
+            [clojure.string :as str :refer [blank? ends-with? includes? join split starts-with? trim]]
+            [cognitect.anomalies :as anom]
+            [fc4.image-utils :refer [bytes->buffered-image buffered-image->bytes png-data-uri->bytes width height]]
+            [fc4.integrations.structurizr.express.spec] ;; for side effects
+            [fc4.rendering :as r :refer [Renderer]]
+            [fc4.util :refer [fault namespaces qualify-keys]]
+            [fc4.yaml :as yaml]))
+
+;; Some of the functions include some type hints or type casts. These are to prevent reflection, but
+;; not for the usual reason of improving performance. In this case, some of the reflection leads to
+;; classes that violate some kind of boundary introduced in Java 9/10/11 and yield an ominous
+;; message printed to stdout (or maybe stderr).
+
+;; Import various Java AWT classes that we need to work with the images — but first set a system
+;; property that will prevent the Java app icon from popping up and grabbing focus on MacOS. That is
+;; why these imports are here rather that in the ns form.
+(System/setProperty "apple.awt.UIElement" "true")
+(import '[java.awt Color Font Image RenderingHints]
+        '[java.awt.image BufferedImage])
+
+;; The private functions that accept a clj-chrome-devtools automation context
+;; are stateful in that they expect the page to be in a certain state before they are called.
+;;
+;; Therefore these functions must be called in a specific order:
+;;
+;; 1. load-structurizr-express
+;; 2. set-yaml-and-update-diagram
+;; 3. extract-diagram and/or extract-key
+
+(def ^:private doc-separator "---\n")
+
+(s/def ::headless boolean?)
+(s/def ::structurizr-express-url string?)
+(s/def ::debug-port nat-int?)
+(s/def ::debug-conn-timeout-ms nat-int?)
+(s/def ::opts (s/keys :opt-un [::headless ::structurizr-express-url]))
+(s/def ::browser #(instance? Process %))
+(s/def ::conn connection?)
+(s/def ::automation automation?)
+(s/def ::prepped-yaml
+  (s/and string?
+         (complement blank?)
+         #(starts-with? % doc-separator)
+         #(not (re-seq #"[^\\]`" %))))
+
+(defn- chromium-path
+  []
+  (let [user-home (System/getProperty "user.home")
+        mac-chromium-path "Applications/Chromium.app/Contents/MacOS/Chromium"
+        mac-chrome-path "Applications/Google Chrome.app/Contents/MacOS/Google Chrome"]
+    (->> (filter #(.canExecute (file %))
+                 [;; On MacOS, prefer a browser installed in a user’s home directory to one
+                  ;; installed system-wide.
+                  (file user-home mac-chromium-path)
+                  (file user-home mac-chrome-path)
+                  (file "/" mac-chromium-path)
+                  (file "/" mac-chrome-path)
+                  "/usr/bin/chromium" ; Debian
+                  "/usr/bin/chromium-browser"]) ; Alpine
+         (first)
+         (str))))
+
+(defn- chromium-opts
+  [opts]
+  (let [{:keys [headless debug-port]} opts]
+    [(chromium-path) ;; TODO: handle this being nil — here, or somewhere else, maybe start-browser
+
+     (str "--remote-debugging-port=" debug-port)
+
+     (if headless "--headless" "")
+
+     ; So as to ensure that tabs from the prior session aren’t restored.
+     "--incognito"
+
+     ; We need this because we’re using the default user in our local Docker-based
+     ; test running environment, which is apparently root, and Chromium won’t
+     ; run as root unless this arg is passed.
+     "--no-sandbox"
+
+     ; Recommended here:
+     ;   https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#tips
+     "--disable-dev-shm-usage"]))
+
+(defn- start-browser
+  [opts]
+  (.exec (Runtime/getRuntime) ^"[Ljava.lang.String;" (into-array (chromium-opts opts))))
+
+(defn- prep-yaml
+  "Structurizr Express will only recognize the YAML as YAML and parse it if
+  it begins with the YAML document separator. If this isn’t present, it will
+  assume that the diagram definition string is JSON and will fail."
+  [yaml]
+  (as-> (yaml/split-file yaml) it
+    (::yaml/main it)
+    (str/replace it "`" "\\`") ; un-escaped backticks interfere when passing YAML in to JS runtime
+    (str doc-separator it)))
+
+(s/fdef prep-yaml
+  :args (s/cat :yaml string?)
+  :ret  ::prepped-yaml)
+
+(defn- load-structurizr-express
+  [automation url]
+  (let [page (a/to automation url)]
+    (if (includes? (:document-url page) "chrome-error")
+      (fault "Could not load Structurizr Express (unknown error; possible connectivity problem)")
+      (when-not (a/visible automation (a/sel1 automation "svg"))
+        (fault "Could not load Structurizr Express (svg node not found)")))))
+
+(s/fdef load-structurizr-express
+  :args (s/cat :automation ::automation
+               :url string?)
+  :ret  (s/or :success nil
+              :failure ::anom/anomaly))
+
+(defn- set-yaml-and-update-diagram
+  [automation yaml]
+  ;; I’m not 100% sure but I suspect it’s important to call hasErrorMessages() after
+  ;; renderExpressDefinition so that the JS runtime finishes the execution of
+  ;; renderExpressDefinition before this (clj) function returns. Before I added the hasErrorMessages
+  ;; call, I was getting errors when subsequently calling exportCurrentDiagramToPNG, and I think
+  ;; they were due to the YAML not actually being fully “set” yet. Honestly I’m not entirely sure.
+  (a/evaluate automation (str "const diagramYaml = `" yaml "`;\n"
+                              "structurizr.scripting.renderExpressDefinition(diagramYaml);"))
+  (when-let [errs (seq (a/evaluate automation "structurizrExpress.getErrorMessages();"))]
+    (str "Error occurred while rendering; errors were found in the diagram definition: "
+         (join "; " (map :message errs)))))
+
+(s/fdef set-yaml-and-update-diagram
+  :args (s/cat :automation ::automation
+               :diagram-yaml ::prepped-yaml)
+  :ret  (s/or :success nil?
+              :err-message string?))
+
+(defn- extract-diagram
+  "Returns, as a bytearray, a PNG image of the current diagram. set-yaml-and-update-diagram must
+  have already been called."
+  [automation]
+  (->> "structurizr.scripting.exportCurrentDiagramToPNG({crop: false});"
+       (a/evaluate automation)
+       (png-data-uri->bytes)))
+
+(defn- extract-key
+  "Returns, as a bytearray, a PNG image of the current diagram’s key. set-yaml-and-update-diagram
+  must have already been called."
+  [automation]
+  (->> "structurizr.scripting.exportCurrentDiagramKeyToPNG();"
+       (a/evaluate automation)
+       (png-data-uri->bytes)))
+
+(defn- conjoin
+  [diagram-image key-image]
+  ; There are a few casts to int below; they’re to avoid reflection.
+  (let [di (bytes->buffered-image diagram-image)
+        ki (bytes->buffered-image key-image)
+        ^Image sk (.getScaledInstance ki (/ (width ki) 2) (/ (height ki) 2) Image/SCALE_SMOOTH)
+        w (max (width di) (width sk))
+        divider-height 2
+        gap 1
+        key-title-y-offset 0 ; Currently 0 for test-compatibility with prior renderer, but I plan to increase this to ~40.
+        key-title-x-offset 35 ; Mainly for test-compatibility with prior renderer, but looks OK.
+        ky (+ (.getHeight di) gap)
+        kx (- (/ w 2) (/ (width sk) 2))
+        h (+ ky (height sk))
+        ci (BufferedImage. w h BufferedImage/TYPE_INT_RGB)]
+    (doto (.createGraphics ci)
+      (.setBackground (Color/white))
+      (.clearRect 0 0 w h)
+
+      (.setColor (Color/gray))
+      (.fillRect 0 (.getHeight di) w divider-height)
+
+      (.drawImage di 0 0 nil)
+      (.drawImage sk (int kx) (int (inc ky)) nil)
+
+      (.setColor (Color/black))
+      (.setFont (Font. Font/SANS_SERIF Font/PLAIN 32))
+      (.setRenderingHint RenderingHints/KEY_TEXT_ANTIALIASING
+                         RenderingHints/VALUE_TEXT_ANTIALIAS_ON)
+      (.drawString "Key" (int (+ kx key-title-y-offset)) (int (+ ky key-title-x-offset))))
+    (buffered-image->bytes ci)))
+
+(defn- do-render
+  "Renders a Structurizr Express diagram as a PNG file, returning a PNG bytearray on success. Not
+  entirely pure; communicates with a child process to perform the rendering."
+  [diagram-yaml automation {:keys [structurizr-express-url]}]
+  ;; Protect developers from themselves
+  {:pre [(not (ends-with? diagram-yaml ".yaml")) (not (ends-with? diagram-yaml ".yml"))]}
+  ;; TODO: LOTS more error handling!
+  (load-structurizr-express automation structurizr-express-url)
+  (if-let [err-msg (set-yaml-and-update-diagram automation (prep-yaml diagram-yaml))]
+    (fault err-msg)
+    (let [diagram-image (extract-diagram automation)
+          key-image (extract-key automation)
+          final-image (conjoin diagram-image key-image)]
+      {::r/png-bytes final-image})))
+
+; This spec is here mainly for documentation and instrumentation. I don’t
+; recommend using it for generative/property testing, mainly because rendering
+; is currently quite slow (~1–3s on my system) and it performs network I/O.
+(s/fdef do-render
+  :args (s/cat :diagram :structurizr/diagram-yaml-str
+               :automation ::automation
+               :opts ::opts)
+  :ret  (s/or :success ::r/success-result
+              :failure ::r/failure-result))
+
+(defrecord ChromiumRenderer [browser conn automation opts]
+  Renderer
+  (render [renderer diagram-yaml] (do-render diagram-yaml automation opts))
+
+  java.io.Closeable
+  (close [renderer] (.destroy (:browser renderer))))
+
+(def default-opts
+  {:structurizr-express-url "https://structurizr.com/express"
+   :headless true
+   :debug-port 9222
+   :debug-conn-timeout-ms 5000})
+
+(defn make-renderer
+  "Creates a ChromiumRenderer. It’s VERY important to call .close on the ChromiumRenderer at some
+  point — best way to ensure that is to call this function using with-open."
+  ([]
+   (make-renderer {}))
+  ([opts]
+   (let [full-opts (merge default-opts opts)
+         browser (start-browser full-opts)
+         {:keys [debug-port debug-conn-timeout-ms]} full-opts
+         conn (chrome/connect "localhost" debug-port debug-conn-timeout-ms)
+         automation (a/create-automation conn)]
+     (->ChromiumRenderer browser conn automation full-opts))))
+
+; This spec is here mainly for documentation and instrumentation. I don’t
+; recommend using it for generative/property testing, mainly because rendering
+; is currently quite slow (~1–3s on my system) and it performs network I/O.
+(s/fdef make-renderer
+  :args (s/? ::opts)
+  :ret  (s/and #(instance? ChromiumRenderer %)
+               (s/keys :req-un [::browser ::conn ::automation])))
+
+(comment
+  (require :reload '[fc4.rendering :as r :refer [render]])
+  (require :reload '[fc4.integrations.structurizr.express.chromium-renderer :refer [make-renderer]])
+  (require '[clojure.spec.test.alpha :as stest]
+           '[fc4.io.util :refer [binary-spit]])
+  (stest/instrument)
+
+  (def test-data-dir "test/data/structurizr/express/")
+  (def filenames
+    {:valid     "diagram_valid_cleaned.yaml"
+     :invalid-a "se_diagram_invalid_a.yaml"
+     :invalid-b "se_diagram_invalid_b.yaml"
+     :invalid-c "se_diagram_invalid_c.yaml"})
+
+  (defonce renderer (atom (make-renderer)))
+
+  ;; Ensure we can render immediately after creating the renderer — that the renderer is immediately
+  ;; ready to go.
+  (with-open [renderer (make-renderer)]
+    (render renderer ""))
+
+  (as-> :valid it
+    (str test-data-dir (get filenames it "????"))
+    (slurp it)
+    (time (render @renderer it))
+    (or (::r/png-bytes it)
+        (println (or (::anom/message it) "WTF")))
+    (when it (binary-spit "/tmp/diagram.png" it)))
+
+  (time (render @renderer ""))
+
+  (.close @renderer)
+  (reset! renderer (make-renderer)))

--- a/tool/src/main/fc4/integrations/structurizr/express/node_renderer.clj
+++ b/tool/src/main/fc4/integrations/structurizr/express/node_renderer.clj
@@ -1,4 +1,4 @@
-(ns fc4.integrations.structurizr.express.render
+(ns fc4.integrations.structurizr.express.node-renderer
   (:require [clojure.java.io      :as io        :refer [file]]
             [clojure.java.shell   :as shell     :refer [sh]]
             [clojure.spec.alpha   :as s]
@@ -87,7 +87,7 @@
 (comment
   (require :reload
            '[fc4.rendering :as rendering :refer [render]]
-           '[fc4.integrations.structurizr.express.render :refer [->NodeRenderer]]
+           '[fc4.integrations.structurizr.express.node-renderer :refer [->NodeRenderer]]
            '[fc4.io.util :refer [binary-spit]])
   (def test-data-dir "test/data/structurizr/express/")
   (def filenames

--- a/tool/src/main/fc4/io/render.clj
+++ b/tool/src/main/fc4/io/render.clj
@@ -10,7 +10,7 @@
             [fc4.files :refer [remove-extension]]
             [fc4.io.util :refer [binary-spit debug err-msg fail read-text-file]]
             [fc4.io.yaml :as yaml]
-            [fc4.integrations.structurizr.express.render :refer [->NodeRenderer]]
+            [fc4.integrations.structurizr.express.node-renderer :refer [->NodeRenderer]]
             [fc4.rendering :as r :refer [render]]
             [fc4.spec :as fs])
   (:import [java.io File FileNotFoundException]))

--- a/tool/src/main/fc4/util.clj
+++ b/tool/src/main/fc4/util.clj
@@ -1,7 +1,8 @@
 (ns fc4.util
   (:require [clojure.walk        :as walk  :refer [postwalk]]
             [clojure.spec.alpha  :as s]
-            [fc4.spec           :as fs]))
+            [cognitect.anomalies :as anom]
+            [fc4.spec            :as fs]))
 
 (s/def ::ns-tuples
   (s/+ (s/tuple simple-symbol? #{:as} simple-symbol?)))
@@ -104,3 +105,10 @@
      (if *throw-on-fail*
        (throw e)
        e))))
+
+(defn fault
+  "Convenience function for constructing an :cognitect.anomalies/anomaly with
+  :cognitect.anomalies/category being :cognitect.anomalies/fault."
+  [message]
+  {::anom/category ::anom/fault
+   ::anom/message message})

--- a/tool/test/fc4/integrations/structurizr/express/chromium_renderer_test.clj
+++ b/tool/test/fc4/integrations/structurizr/express/chromium_renderer_test.clj
@@ -1,0 +1,125 @@
+(ns fc4.integrations.structurizr.express.chromium-renderer-test
+  (:require [fc4.integrations.structurizr.express.chromium-renderer :as cr :refer [make-renderer]]
+            [fc4.io.util :refer [binary-spit binary-slurp]]
+            [fc4.rendering :as r :refer [render]]
+            [fc4.test-utils :refer [check]]
+            [fc4.test-utils.image-diff :refer [bytes->buffered-image image-diff]]
+            [clojure.java.io :refer [copy file input-stream output-stream]]
+            [clojure.spec.alpha :as s]
+            [clojure.string :refer [includes?]]
+            [clojure.test :refer [deftest testing is]]
+            [cognitect.anomalies :as anom]
+            [expound.alpha :as expound :refer [expound-str]]
+
+            ; I’d prefer to use Orchestra but it’s not quite working right now. TODO.
+            ;[orchestra.spec.test :as stest]
+            [clojure.spec.test.alpha :as stest]))
+
+(set! *warn-on-reflection* true)
+
+(->> (ns-interns 'fc4.integrations.structurizr.express.chromium-renderer)
+     (vals)
+     (map symbol)
+     (stest/instrument))
+(set! s/*explain-out* expound/printer)
+
+; Require image-resizer.core while preventing the Java app icon from popping up
+; and grabbing focus on MacOS.
+; Approach found here: https://stackoverflow.com/questions/17460777/stop-java-coffee-cup-icon-from-appearing-in-the-dock-on-mac-osx/17544259#comment48475681_17544259
+; This require is here rather than in the ns form at the top of the file because
+; if I include this ns in the require list in the ns form, then the only way to
+; suppress the app icon from popping up and grabbing focus would be to place the
+; System/setProperty call at the top of the file, before the ns form, and that’d
+; violate Clojure idioms. When people open a clj file, they expect to see a ns
+; form right at the top declaring which namespace the file defines and
+; populates.
+; To be clear, calling the `require` function in a clj file, to require a
+; dependency, outside of the ns form, is *also* non-idiomatic; people expect all
+; of the dependencies of a file to be listed in the ns form. So I had to choose
+; between two non-idiomatic solutions; I chose this one because it seems to me
+; to be slightly less jarring for Clojurists.
+(do
+  (System/setProperty "apple.awt.UIElement" "true")
+  (require '[image-resizer.core :refer [resize]]))
+
+(def max-allowable-image-difference
+  ;; This threshold might seem low, but the diffing algorithm is
+  ;; giving very low results for some reason. This threshold seems
+  ;; to be sufficient to make the random watermark effectively ignored
+  ;; while other, more significant changes (to my eye) seem to be
+  ;; caught. Still, this is pretty unscientific, so it might be worth
+  ;; looking into making this more precise and methodical.
+  0.005)
+
+(def dir "test/data/structurizr/express/")
+
+(defn temp-png-file
+  [basename]
+  (java.io.File/createTempFile basename ".png"))
+
+(deftest rendering
+  (with-open [renderer (make-renderer)]
+    (testing "happy paths"
+      (testing "rendering a Structurizr Express file"
+        (let [yaml (slurp (file dir "diagram_valid_cleaned.yaml"))
+              {:keys [::r/png-bytes] :as result} (render renderer yaml)
+              actual-bytes png-bytes
+              expected-bytes (binary-slurp (file dir "diagram_valid_cleaned_expected.png"))
+              difference (->> [actual-bytes expected-bytes]
+                              (map bytes->buffered-image)
+                              (map #(resize % 1000 1000))
+                              (reduce image-diff))]
+          (is (s/valid? ::r/success-result result)
+              (expound-str ::r/success-result result))
+          (is (<= difference max-allowable-image-difference)
+              ;; NB: below in addition to returning a message we write the actual
+              ;; bytes out to the file system, to help with debugging. But
+              ;; apparently `is` evaluates this `msg` arg eagerly, so it’s
+              ;; evaluated even if the assertion is true. This means that even
+              ;; when the test passes the “expected” file is written out to the
+              ;; filesystem. So TODO: maybe we should do something about this.
+              (let [expected-debug-fp (temp-png-file "rendered_expected.png")
+                    actual-debug-fp (temp-png-file "rendered_actual.png")]
+                (binary-spit expected-debug-fp expected-bytes)
+                (binary-spit actual-debug-fp actual-bytes)
+                (str "Images are "
+                     difference
+                     " different, which is higher than the threshold of "
+                     max-allowable-image-difference
+                     "\n“expected” PNG written to:" (.getPath expected-debug-fp)
+                     "\n“actual” PNG written to:" (.getPath actual-debug-fp)))))))
+    (testing "sad path:"
+      ;; The specs for some functions specify *correct* inputs. So in order to test what they do
+      ;; with *incorrect* inputs, we need to un-instrument them.
+      (->> ["do-render" "set-yaml-and-update-diagram"]
+           (map #(str "fc4.integrations.structurizr.express.chromium-renderer/" %))
+           (map symbol)
+           (stest/unstrument))
+      (testing "inputs that contain no diagram definition whatsoever"
+        (doseq [input [""
+                       "this is not empty, but it’s not a diagram!"]]
+          (let [{:keys [::anom/message] :as result} (render renderer input)]
+            (is (s/valid? ::r/failure-result result)
+                (expound-str ::r/failure-result result))
+            (is (includes? message "errors were found in the diagram definition"))
+            (is (includes? message "No diagram has been defined")))))
+      (testing "inputs that contain invalid diagram definitions"
+        (doseq [[fname-suffix expected-strings]
+                {"a.yaml" ["Diagram scope" "software system named" "undefined" "could not be found"]
+                 "b.yaml" ["The diagram type must be" "System Landscape" "Dynamic"]
+                 "c.yaml" ["relationship destination element named" "Does not exist" "does not exist"]}]
+          (testing fname-suffix
+            (let [path (file dir (str "se_diagram_invalid_" fname-suffix))
+                  input (slurp path)
+                  {:keys [::anom/message] :as result} (render renderer input)]
+              (when (::r/png-bytes result)
+                (let [png-bytes (::r/png-bytes result)
+                      tmp-file  (temp-png-file "unexpected")]
+                  (binary-spit tmp-file png-bytes)
+                  (println "Wrote unexpected diagram image to" tmp-file)))
+              (is (s/valid? ::r/failure-result result)
+                  (expound-str ::r/failure-result result))
+              (is (every? #(includes? message %) expected-strings))
+              (is (includes? message "errors were found in the diagram definition")))))))))
+
+(deftest prep-yaml (check `cr/prep-yaml))

--- a/tool/test/fc4/integrations/structurizr/express/chromium_renderer_test.clj
+++ b/tool/test/fc4/integrations/structurizr/express/chromium_renderer_test.clj
@@ -15,8 +15,12 @@
             ;[orchestra.spec.test :as stest]
             [clojure.spec.test.alpha :as stest]))
 
+;; TODO: maybe add this to the project’s custom test runner runner.
 (set! *warn-on-reflection* true)
 
+;; At first I just called instrument with no args, but I ran into trouble with some specs/fns inside
+;; clj-chrome-devtools. So I came up with this overwrought approach to instrumenting only the functions in
+;; the namespace under test.
 (->> (ns-interns 'fc4.integrations.structurizr.express.chromium-renderer)
      (vals)
      (map symbol)

--- a/tool/test/fc4/integrations/structurizr/express/node_renderer_test.clj
+++ b/tool/test/fc4/integrations/structurizr/express/node_renderer_test.clj
@@ -1,5 +1,5 @@
-(ns fc4.integrations.structurizr.express.render-test
-  (:require [fc4.integrations.structurizr.express.render :refer [->NodeRenderer]]
+(ns fc4.integrations.structurizr.express.node-renderer-test
+  (:require [fc4.integrations.structurizr.express.node-renderer :refer [->NodeRenderer]]
             [fc4.io.util :refer [binary-spit binary-slurp]]
             [fc4.rendering :as r]
             [fc4.test-utils.image-diff :refer [bytes->buffered-image image-diff]]


### PR DESCRIPTION
Background in #155.

This PR adds the Clojure renderer alongside the Node renderer — it’s tested, but it’s not yet user-accessible. That’ll be done next: #159.

Closes #157.