### PR TITLE
[tool] Decouple two more features: edit + watch

### DIFF
--- a/tool/src/cli/fc4/cli/edit.clj
+++ b/tool/src/cli/fc4/cli/edit.clj
@@ -3,10 +3,11 @@
   are observed to a YAML file, the YAML in the file is cleaned up and rendered
   to an image file."
   (:require [fc4.cli.util :refer [fail]]
-            [fc4.io.edit :refer [start]]))
+            [fc4.io.edit :refer [process-file]]
+            [fc4.io.watch :refer [start]]))
 
 (defn block
-  [{:keys [thread] :as hawk-watch}]
+  [{:keys [thread] :as _hawk-watch}]
   (.join thread))
 
 (defn -main
@@ -18,4 +19,4 @@
   [& paths]
   (when (empty? paths)
     (fail "usage: fc4 edit [path ...]"))
-  (block (apply start paths)))
+  (block (start process-file paths)))

--- a/tool/src/main/fc4/io/edit.clj
+++ b/tool/src/main/fc4/io/edit.clj
@@ -1,56 +1,23 @@
 (ns fc4.io.edit
-  "CLI workflow that watches Structurizr Express diagram files; when changes
-  are observed to a YAML file, the YAML in the file is cleaned up and rendered
-  to an image file."
+  "CLI action that processes diagram YAML files: the YAML in the file is formatted and snapped, and
+  the diagram rendered is to an image file. Intended to be invoked via the watching feature in
+  fc4.io.watch."
   (:require [clj-yaml.core :refer [parse-string]]
             [fc4.integrations.structurizr.express.format :as f :refer [reformat]]
             [fc4.integrations.structurizr.express.snap :refer [snap-to-grid]]
             [fc4.integrations.structurizr.express.yaml :as sy :refer [stringify]]
             [fc4.io.render :refer [render-diagram-file]]
-            [fc4.io.util :refer [beep fail print-now read-text-file]]
+            [fc4.io.util :refer [fail print-now read-text-file]]
             [fc4.io.yaml :refer [validate yaml-file?]]
-            [fc4.yaml :as fy :refer [assemble split-file]]
-            [hawk.core :as hawk])
+            [fc4.yaml :as fy :refer [assemble split-file]])
   (:import [java.io File OutputStreamWriter]
            [java.time LocalTime]
            [java.time.temporal ChronoUnit]
            [java.util.concurrent Executors ExecutorService]))
 
-(defn secs-since
-  [inst]
-  (.between (ChronoUnit/SECONDS) inst (LocalTime/now)))
-
-(defn process-fs-event?
-  [active-set _context {:keys [kind file] :as _event}]
-  (and (#{:create :modify} kind)
-       (yaml-file? file)
-       (not (contains? @active-set file))))
-
-(def event-kind->past-tense
-  {:create "created"
-   :modify "modified"
-   :delete "deleted"})
-
-(def ^:private secs-threshold-to-print-event-time 10)
-
 (def defaults
   {:snap {:to-closest 100
           :min-margin 50}})
-
-(defn ^:private remove-nanos
-  [instant]
-  (.withNano instant 0))
-
-(defn- event-preamble
-  [event-ts event-kind file]
-  (str (remove-nanos (LocalTime/now))
-       " "
-       (.getName file)
-       " "
-       (event-kind->past-tense event-kind)
-       (when (> (secs-since event-ts) secs-threshold-to-print-event-time)
-         (str " at " (remove-nanos event-ts)))
-       ";"))
 
 (defn- format-and-snap
   "This function should be fairly short-lived. Right now this edit workflow *always* formats,
@@ -68,92 +35,18 @@
             (stringify)
             (->> (assemble front)))))
 
-(defn- process-file
-  [active-set event-ts event-kind ^File file]
-  (print-now (event-preamble event-ts event-kind file))
-  (try
-    (print-now " reading+parsing...")
-    (let [yaml-in (read-text-file file)
-          ; optimization opportunity: the YAML is being parsed twice, by both validate & format-and-snap
-          _ (validate yaml-in file) ; throws if invalid
-          _ (print-now "✅ formatting+snapping...")
-          yaml-out (format-and-snap yaml-in)]
-      (if (string? yaml-out)
-        (spit file yaml-out)
-        ;; TODO: this is a really crappy error message — there are no details, no actionable
-        ;; info. Fix this!
-        (fail file (str "Unknown error; result of processing was:" yaml-out))))
-    (print-now "✅ rendering...")
-    (render-diagram-file file)
-    (println "✅")
-    (catch Exception e
-      (beep) ; good chance the user’s terminal is in the background
-      (println "🚨" (or (.getMessage e) e)))
-    (finally
-      (swap! active-set disj file))))
-
-(defn process-fs-event
-  [active-set executor out _context {:keys [kind file] :as _event}]
-  (swap! active-set conj file)
-  ;; TODO: we should consider invoking the fast+local operations, formatting and snapping,
-  ;; right here+now in synchronous blocking fashion, and only enqueuing rendering via the
-  ;; executor; that way the user would see the changes from formatting and snapping almost
-  ;; instantly. The only challenging aspect of this that I can think of is that it would
-  ;; introduce concurrent file processing, which would require refactoring how status/progress
-  ;; is written to the user’s terminal. (It’d probably be the best UX if it was stateful.)
-  (let [event-ts (LocalTime/now)]
-    (.execute executor
-              (fn []
-                ;; I don’t know why, but for some reason when this function is
-                ;; run in the Executor’s thread, *out* appears to be bound to
-                ;; some other writer, rather than the default writer that is the
-                ;; root binding. This re-binds *out* to the writer passed in as
-                ;; out, which enables us to have multiple instances of this
-                ;; workflow run simultaneously and print to independent writers
-                ;; so that the output can be examined in test assertions without
-                ;; concern of those multiple workflows sharing the same writer.
-                (binding [*out* out]
-                  (process-file active-set event-ts kind file))))))
-
-(defn start
-  "Starts a hawk watch and returns the watch object, enriched with a few keys
-  specific to this workflow: :executor and :active-set. You can pass the result
-  to stop to stop both the executor and hawk’s background thread, after which
-  they should be garbage-collected, if you don’t hold on to a reference."
-  [& paths]
-  (let [; The set of files that are being processed or are enqueued to be processed.
-        ; This is used to discard subsequent file modification events that occur while a
-        ; file is being processed or is enqueued to be processed — this is crucial
-        ; because there’s always _at least_ one subsequent modification event, because
-        ; the files are modified by process-file 😵!"
-        active-set (atom #{})
-
-        ;; I don’t know why, but for some reason when our handler function is
-        ;; run in the Executor’s thread, *out* appears to be bound to some other
-        ;; writer, rather than the default writer that is the root binding. So
-        ;; we’ll provide that default writer from _this_ thread to the handler
-        ;; function (using partial, see below). This enables us to have multiple
-        ;; instances of this workflow run simultaneously and print to
-        ;; independent writers so that the output can be examined in test
-        ;; assertions without concern of those multiple workflows sharing the
-        ;; same writer.
-        out *out*
-
-        ; The actual event processing has to occur in a different thread than
-        ; the Hawk background thread, because rendering is blocking and very
-        ; slow, and we need to process filesystem events quickly with low
-        ; latency.
-        executor   (Executors/newSingleThreadExecutor)
-        watch      (hawk/watch!
-                    [{:paths   paths
-                      :filter  (partial process-fs-event? active-set)
-                      :handler (partial process-fs-event active-set executor out)}])
-        result     (assoc watch :active-set active-set, :executor executor)]
-    (println "📣 Now watching for changes to YAML files under specified paths...")
-    result))
-
-(defn stop
-  "Useful during development and testing."
-  [{:keys [executor] :as watch}]
-  (hawk/stop! watch)
-  (.shutdownNow executor))
+(defn process-file
+  [^File file]
+  (print-now " reading+parsing...")
+  (let [yaml-in (read-text-file file)
+        ; optimization opportunity: the YAML is being parsed twice, by both validate & format-and-snap
+        _ (validate yaml-in file) ; throws if invalid
+        _ (print-now "✅ formatting+snapping...")
+        yaml-out (format-and-snap yaml-in)]
+    (if (string? yaml-out)
+      (spit file yaml-out)
+      ;; TODO: this is a really crappy error message — there are no details, no actionable
+      ;; info. Fix this!
+      (fail file (str "Unknown error; result of processing was:" yaml-out))))
+  (print-now "✅ rendering...")
+  (render-diagram-file file))

--- a/tool/src/main/fc4/io/watch.clj
+++ b/tool/src/main/fc4/io/watch.clj
@@ -1,0 +1,144 @@
+(ns fc4.io.watch
+  "Functions related to watching paths and invoking functions when those paths change."
+  (:require [fc4.io.util :refer [beep debug print-now]]
+            [fc4.io.yaml :refer [yaml-file?]]
+            [hawk.core :as hawk])
+  (:import [java.io File OutputStreamWriter]
+           [java.time LocalTime]
+           [java.time.temporal ChronoUnit]
+           [java.util.concurrent Executors ExecutorService]))
+
+(defn secs-since
+  [inst]
+  (.between (ChronoUnit/SECONDS) inst (LocalTime/now)))
+
+(defn ms-since
+  [inst]
+  (.between (ChronoUnit/MILLIS) inst (LocalTime/now)))
+
+(def ^:private secs-threshold-to-print-event-time 10)
+(def ^:private min-ms-between-changes 1200)
+
+(defn process-fs-event?
+  [{:keys [active-set recent-set] :as _context}
+   {:keys [kind file] :as _event}]
+  (let [in-active-set (contains? @active-set file)
+        in-recent-set (contains? recent-set file)
+        last-processed (get recent-set file)
+        since-processed (when in-recent-set (ms-since last-processed))
+        process? (and (#{:create :modify} kind)
+                      (yaml-file? file)
+                      (not in-active-set)
+                      (or (not in-recent-set)
+                          (>= since-processed min-ms-between-changes)))]
+    (debug (.getName file) "\n"
+           "  in active set:  " in-active-set "\n"
+           "  in recent set:  " in-recent-set "\n"
+           "  last-processed: " (str last-processed) "\n"
+           "  current time:   " (str (LocalTime/now)) "\n"
+           "  since-processed:" since-processed "\n"
+           "  process?:       " process?)
+    process?))
+
+(def event-kind->past-tense
+  {:create "created"
+   :modify "modified"
+   :delete "deleted"})
+
+(defn ^:private remove-nanos
+  [instant]
+  (.withNano instant 0))
+
+(defn- event-preamble
+  [event-ts event-kind file]
+  (str (remove-nanos (LocalTime/now))
+       " "
+       (.getName file)
+       " "
+       (event-kind->past-tense event-kind)
+       (when (> (secs-since event-ts) secs-threshold-to-print-event-time)
+         (str " at " (remove-nanos event-ts)))
+       ";"))
+
+(defn process-fs-event
+  [{:keys [active-set process-fn executor out] :as context}
+   {:keys [kind file] :as _event}]
+  (swap! active-set conj file)
+  (let [event-ts (LocalTime/now)]
+    (.execute executor
+              (fn []
+                ;; I don’t know why, but for some reason when this function is
+                ;; run in the Executor’s thread, *out* appears to be bound to
+                ;; some other writer, rather than the default writer that is the
+                ;; root binding. This re-binds *out* to the writer passed in as
+                ;; out, which enables us to have multiple instances of this
+                ;; workflow run simultaneously and print to independent writers
+                ;; so that the output can be examined in test assertions without
+                ;; concern of those multiple workflows sharing the same writer.
+                (binding [*out* out]
+                  (print-now (event-preamble event-ts kind file))
+                  (try
+                    (process-fn file)
+                    (println "✅")
+                    (catch Exception e
+                      (beep) ; good chance the user’s terminal is in the background
+                      (println "🚨" (or (.getMessage e) e)))
+                    (finally
+                      (swap! active-set disj file))))))
+    (assoc-in context [:recent-set file] event-ts)))
+
+(defn start
+  "Starts a hawk watch and returns the watch object, enriched with a few keys
+  specific to this workflow: :executor and :active-set. You can pass the result
+  to stop to stop both the executor and hawk’s background thread, after which
+  they should be garbage-collected, if you don’t hold on to a reference.
+
+  process-fn must be a single-arity (or variable-arity) function that accepts a
+  File object pointing to a file that’s been changed and should be processed. It
+  may do I/O and may block. It may change the file. It may throw exceptions. Its
+  return value is ignored; it’s invoked for its side effects.
+
+  The watch routine will automatically print (to *out*) the file name before
+  invoking the function, and afterwards will print ✅ if the invocation didn’t
+  throw, and 🚨 plus a message if it did, then a newline. process-fn should
+  ideally print some message that indicates what it’s doing."
+  [process-fn paths]
+  (let [context {:process-fn process-fn
+
+                 ;; The set of files that are being processed or are enqueued to be processed. This
+                 ;; is used to discard subsequent file modification events that occur while a file
+                 ;; is being processed or is enqueued to be processed — this is crucial because
+                 ;; there’s often a subsequent modification event, maybe even multiple events,
+                 ;; because the files are modified by process-file 😵!"
+                 :active-set (atom #{})
+
+                 ;; Map of File objects to LocalTime objects that are the timestamp of the most
+                 ;; recently observed filesystem event.
+                 :recent-set {}
+
+                 ;; I don’t know why, but for some reason when our handler function is run in the
+                 ;; Executor’s thread, *out* appears to be bound to some other writer, rather than
+                 ;; the default writer that is the root binding. So we’ll provide that default
+                 ;; writer from _this_ thread to the handler function (using partial, see below).
+                 ;; This enables us to have multiple instances of this workflow run simultaneously
+                 ;; and print to independent writers so that the output can be examined in test
+                 ;; assertions without concern of those multiple workflows sharing the same writer.
+                 :out *out*
+
+                 ;; The actual event processing has to occur in a different thread than the Hawk
+                 ;; background thread, because rendering is blocking and very slow, and we need to
+                 ;; process filesystem events quickly with low latency.
+                 :executor (. Executors newSingleThreadExecutor)}
+        watch (hawk/watch!
+               [{:paths   paths
+                 :context (constantly context)
+                 :filter  process-fs-event?
+                 :handler process-fs-event}])]
+    (println "📣 Now watching for changes to YAML files under specified paths...")
+    (merge watch context)))
+
+(defn stop
+  "Useful during development and testing."
+  [{:keys [executor] :as watch}]
+  (hawk/stop! watch)
+  (.shutdownNow executor))

--- a/tool/test/data/structurizr/express/se_diagram_invalid_b_formatted_snapped.yaml
+++ b/tool/test/data/structurizr/express/se_diagram_invalid_b_formatted_snapped.yaml
@@ -1,6 +1,3 @@
-# This file is invalid to Structurizr Express, because of the incorrect value for “Type” — but it’s
-# valid to fc4-tool, which doesn’t currently validate that property. This is a useful situation to
-# test.
 links:
   The FC4 Framework: https://fundingcircle.github.io/fc4-framework/
   Structurizr Express: https://structurizr.com/express
@@ -10,19 +7,18 @@ scope: Acme inc.
 description: Big-picture diagram showing how our top-level systems and stakeholders interact
 
 elements:
-- type: "Person"
-  name: "A"
+- type: Person
+  name: A
   tags: foo, bar,foo_bar,foo-bar
-  position: '123,52'
+  position: '125,50'
 - type: Software System
-  name: "B"
-  style: ""
-  position: '805,109'
+  name: B
+  position: '800,100'
 
 relationships:
-- source: "A"
-  description: "interacts with"
-  destination: "B"
+- source: A
+  description: interacts with
+  destination: B
 
 styles:
 - type: element

--- a/tool/test/data/structurizr/express/se_diagram_invalid_d.yaml
+++ b/tool/test/data/structurizr/express/se_diagram_invalid_d.yaml
@@ -1,6 +1,5 @@
-# This file is invalid to Structurizr Express, because of the incorrect value for “Type” — but it’s
-# valid to fc4-tool, which doesn’t currently validate that property. This is a useful situation to
-# test.
+# This is subtly invalid such that it will pass our basic validation routines, but will cause
+# formatting+snapping to fail.
 links:
   The FC4 Framework: https://fundingcircle.github.io/fc4-framework/
   Structurizr Express: https://structurizr.com/express
@@ -10,14 +9,11 @@ scope: Acme inc.
 description: Big-picture diagram showing how our top-level systems and stakeholders interact
 
 elements:
-- type: "Person"
-  name: "A"
-  tags: foo, bar,foo_bar,foo-bar
-  position: '123,52'
+- "foo"
 - type: Software System
   name: "B"
   style: ""
-  position: '805,109'
+  position: '😱'
 
 relationships:
 - source: "A"

--- a/tool/test/fc4/io/edit_test.clj
+++ b/tool/test/fc4/io/edit_test.clj
@@ -43,108 +43,104 @@
 
 (deftest format-and-snap
   (let [f #'e/format-and-snap
-        valid-before   "test/data/structurizr/express/diagram_valid_messy.yaml"
-        valid-expected "test/data/structurizr/express/diagram_valid_formatted_snapped.yaml"
-        invalid-a      "test/data/structurizr/express/se_diagram_invalid_a.yaml"
-        invalid-b      "test/data/structurizr/express/se_diagram_invalid_b.yaml"]
+        valid-before       "test/data/structurizr/express/diagram_valid_messy.yaml"
+        valid-expected     "test/data/structurizr/express/diagram_valid_formatted_snapped.yaml"
+        invalid-a          "test/data/structurizr/express/se_diagram_invalid_a.yaml"
+        invalid-b          "test/data/structurizr/express/se_diagram_invalid_b.yaml"
+        invalid-b-expected "test/data/structurizr/express/se_diagram_invalid_b_formatted_snapped.yaml"]
     (testing "a YAML string containing a valid SE diagram"
       (is (= (slurp valid-expected)
              (f (slurp valid-before)))))
     (testing "a YAML string containing a blatantly invalid SE diagram"
       (let [yaml (slurp invalid-a)]
+        ; We compare the main documents only so we can ignore the comments at the top of the files.
         (is (= (-> yaml split-file ::fy/main parse-string)
                (-> yaml f split-file ::fy/main parse-string)))))
     (testing "a YAML string containing a subtly invalid SE diagram"
-      (let [yaml (slurp invalid-b)]
-        (is (= (-> yaml split-file ::fy/main parse-string)
-               (-> yaml f split-file ::fy/main parse-string)))))
+      ; ...invalid to Structurizr Express but not to this tool.
+      ; We compare the main documents only so we can ignore the comments at the top of the files.
+      (is (= (-> invalid-b-expected slurp   split-file ::fy/main)
+             (-> invalid-b          slurp f split-file ::fy/main))))
     (testing "an empty string"
       (is (nil? (f ""))))))
 
-;; The tests below don’t thoroughly check the specific features that are called by the edit workflow
-;; (formatting, snapping, and rendering) because those have their own focused tests already.
-;; Therefore it’s sufficient for these tests to simply confirm that those features have been
-;; invoked.
-
-;; It’s common for tests to be broader than these, and to use `testing` to test
-;; various scenarios. These tests are smaller and more specific, using basically
-;; one deftest per scenario, because they are very slow, and these test
-;; functions are our units of concurrency. By breaking them into multiple
-;; top-level deftests, they can run in parallel.
-
-(deftest edit-workflow-single-file-single-change
-  (testing "changing a single file once"
-    (let [yaml-expected "test/data/structurizr/express/diagram_valid_formatted_snapped.yaml"
-          yaml-input "test/data/structurizr/express/diagram_valid_messy.yaml"
-          yaml-file (tmp-copy yaml-input)
+(deftest process-file
+  ;; These tests don’t thoroughly check the specific features that are called by the edit workflow
+  ;; (formatting, snapping, and rendering) because those have their own focused tests already.
+  ;; Therefore it’s sufficient for these tests to simply confirm that those features have been
+  ;; invoked.
+  (testing "simple happy path"
+    (let [yaml-file (tmp-copy "test/data/structurizr/express/diagram_valid_messy.yaml")
+          yaml-expected "test/data/structurizr/express/diagram_valid_formatted_snapped.yaml"
           png-file (file (set-extension yaml-file "png"))
           yaml-file-size-before (.length yaml-file)
           _ (is (or (not (.exists png-file))
                     (.delete png-file)))
-          watch (atom nil)
           output (with-out-str
-                   (reset! watch (e/start (str yaml-file)))
-                   (Thread/sleep 100)
-                   (append yaml-file "\n")
-                   (Thread/sleep 12000))]
-      (e/stop @watch)
+                   (e/process-file yaml-file))]
       (is (.exists png-file))
       (is (not= yaml-file-size-before (.length yaml-file)))
       (is (= (slurp yaml-expected) (slurp yaml-file)))
       (is (<= 50000 (.length png-file)))
-      (is (= 3 (count-substring output "✅")))
-      (is (= 2 (count (split-lines output))))
+      (is (= 2 (count-substring output "✅")))
+      (is (= 0 (count-substring output "🚨")))
+      (is (= 1 (count (split-lines output))))
       (delete-file yaml-file)
-      (delete-file png-file))))
-
-(deftest edit-workflow-error-should-not-break-watch
-  ;; We had a bug wherein if an exception was thrown while rendering — and the
-  ;; current workflow does use exceptions, to my regret — further changes to
-  ;; that file would not trigger processing.
-  (testing "a rendering error should not break the watch for that file"
-    (let [yaml-file (tmp-copy "test/data/structurizr/express/se_diagram_invalid_c.yaml")
-          watch (atom nil)
+      (delete-file png-file)))
+  (testing "sad path: formatting+snapping succeeds, but rendering fails"
+    (let [yaml-file (tmp-copy "test/data/structurizr/express/se_diagram_invalid_b.yaml")
+          yaml-expected "test/data/structurizr/express/se_diagram_invalid_b_formatted_snapped.yaml"
+          png-file (file (set-extension yaml-file "png"))
+          yaml-file-size-before (.length yaml-file)
+          _ (is (or (not (.exists png-file))
+                    (.delete png-file)))
           output (with-out-str
-                   (reset! watch (e/start (str yaml-file)))
-                   (Thread/sleep 100)
-                   (append yaml-file "\n")
-                   (Thread/sleep 5000)
-                   (append yaml-file "\n")
-                   (Thread/sleep 5000))]
-      (e/stop @watch)
-      (is (= 4 (count-substring output "✅")))
-      (is (= 2 (count-substring output "🚨")))
-      (is (= 2 (count-substring output "💀")))
-      (is (= 5 (count (split-lines output))))
+                   (is (thrown-with-msg?
+                        Exception
+                        #"(?s)Error processing.+RENDERING FAILED.+Errors were found in the diagram definition.+diagram type must be"
+                        (e/process-file yaml-file))))]
+      (is (not (.exists png-file)))
+      (is (not= yaml-file-size-before (.length yaml-file)))
+      ; We compare the main documents only so we can ignore the comments at the top of the files.
+      (is (= (-> yaml-expected slurp split-file ::fy/main)
+             (-> yaml-file     slurp split-file ::fy/main)))
+      (is (= 2 (count-substring output "✅")))
+      (is (= 0 (count-substring output "🚨")))
+      (is (= 1 (count (split-lines output))))
+      (delete-file yaml-file)))
+  (testing "sad path: file contents are subtly invalid, so validation passes, but
+           formatting/snapping fails"
+    (let [original-file "test/data/structurizr/express/se_diagram_invalid_d.yaml"
+          yaml-file (tmp-copy original-file)
+          png-file (file (set-extension yaml-file "png"))
+          yaml-file-size-before (.length yaml-file)
+          _ (is (or (not (.exists png-file))
+                    (.delete png-file)))
+          output (with-out-str
+                   (is (thrown? Exception
+                                (e/process-file yaml-file))))]
+      (is (not (.exists png-file)))
+      (is (= yaml-file-size-before (.length yaml-file)))
+      (is (= (slurp original-file) (slurp yaml-file)))
+      (is (= 1 (count-substring output "✅")))
+      (is (= 0 (count-substring output "🚨")))
+      (is (= 1 (count (split-lines output))))
+      (delete-file yaml-file)))
+  (testing "sad path: file contents are blatantly invalid, so validation should throw, and no
+           formatting, snapping or rendering should occur"
+    (let [yaml-file (tmp-copy "test/data/structurizr/express/se_diagram_invalid_a.yaml")
+          png-file (file (set-extension yaml-file "png"))
+          yaml-file-size-before (.length yaml-file)
+          _ (is (or (not (.exists png-file))
+                    (.delete png-file)))
+          output (with-out-str
+                   (is (thrown-with-msg?
+                        Exception
+                        #"(?s)Error processing.+Spec failed.+invalid because it is missing the root property.+scope"
+                        (e/process-file yaml-file))))]
+      (is (not (.exists png-file)))
+      (is (= yaml-file-size-before (.length yaml-file)))
+      (is (= 0 (count-substring output "✅")))
+      (is (= 0 (count-substring output "🚨")))
+      (is (= 1 (count (split-lines output))))
       (delete-file yaml-file))))
-
-(deftest edit-workflow-two-files-changed-simultaneously
-  (testing "changing two files simultaneously"
-    (let [yaml-expected "test/data/structurizr/express/diagram_valid_formatted_snapped.yaml"
-          yaml-input "test/data/structurizr/express/diagram_valid_messy.yaml"
-          yaml-files (repeatedly 2 #(tmp-copy yaml-input))
-          png-files (map #(file (set-extension % "png")) yaml-files)
-          yaml-file-size-before (.length (first yaml-files)) ; they’re identical
-          _ (doseq [png-file png-files]
-              (is (or (not (.exists png-file))
-                      (.delete png-file))))
-          watch (atom nil)
-          output (with-out-str
-                   (reset! watch (apply e/start yaml-files))
-                   (Thread/sleep 100)
-                   (run! #(append % "\n") yaml-files)
-                   (Thread/sleep 18000))]
-      (e/stop @watch)
-      (is (= 6 (count-substring output "✅"))
-          (str "Output should have had 6 ✅:\n"
-               output
-               "\n»» Maybe rendering timed out or just took longer than the sleep above?"))
-      (is (= 3 (count (split-lines output))))
-      (doseq [png-file png-files]
-        (is (.exists png-file))
-        (is (<= 50000 (.length png-file)))
-        (delete-file png-file))
-      (doseq [yaml-file yaml-files]
-        (is (not= (.length yaml-file) yaml-file-size-before))
-        (is (= (slurp yaml-expected) (slurp yaml-file)))
-        (delete-file yaml-file)))))

--- a/tool/test/fc4/io/watch_test.clj
+++ b/tool/test/fc4/io/watch_test.clj
@@ -1,0 +1,90 @@
+(ns fc4.io.watch-test
+  (:require [clojure.java.io :refer [copy delete-file file writer]]
+            [clojure.string :refer [split-lines]]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [fc4.files :refer [get-extension remove-extension set-extension]]
+            [fc4.io.watch :as e]
+            [fc4.io.util :as u])
+  (:import [java.io File]))
+
+(defn count-substring
+  {:source "https://rosettacode.org/wiki/Count_occurrences_of_a_substring#Clojure"}
+  [txt sub]
+  (count (re-seq (re-pattern sub) txt)))
+
+(defn append
+  [f v]
+  (with-open [w (writer f :append true)]
+    (.write w v)))
+
+(defn tmp-copy
+  "Creates a new tempfile with a very similar name to the input file/path
+  and the same contents as the file/path. Returns a File object pointing to
+  the tempfile."
+  [source-file]
+  (let [source (file source-file) ; just in case the source was a string
+        base-name (remove-extension source)
+        suffix (str "." (get-extension source))
+        dir (.getParentFile source)
+        tmp-file (File/createTempFile base-name suffix dir)]
+    (copy source tmp-file)
+    tmp-file))
+
+(defn no-debug
+  "Ensure that debug messages don’t get printed, so we can make assertions about
+  the output of the functions under test."
+  [f]
+  (reset! u/debug? false)
+  (f))
+
+(use-fixtures :each no-debug)
+
+(deftest watch
+  (testing "changing a single file once"
+    ;; ...should trigger a single invocation of the process fn, even though the process fn changes
+    ;; the file.
+    (let [yaml-file (tmp-copy "test/data/structurizr/express/diagram_valid_messy.yaml")
+          invocations (atom 0)
+          f (fn [fp]
+              (swap! invocations inc)
+              (when (< @invocations 5) ; failsafe
+                ; change the file, which hopefully will not trigger the watch again
+                (append fp "ha!\n")))
+          watch (delay (e/start f [yaml-file])) ; watch needs to be started inside the with-out-str
+          output (with-out-str
+                   (force watch)
+                   (Thread/sleep 100)
+                   (append yaml-file "yo!\n") ; change the file, triggering the watch
+                   (Thread/sleep 3000))]
+      (e/stop @watch)
+      (is (= 1 @invocations))
+      (is (= 1 (count-substring (slurp yaml-file) "ha!")))
+      (is (= 2 (count (split-lines output))) (str "output: " output))
+      (delete-file yaml-file)))
+  ;; We had a bug wherein if an exception was thrown while rendering — and the
+  ;; current workflow does use exceptions, to my regret — further changes to
+  ;; that file would not trigger processing.
+  (testing "an error should not break the watch for that file"
+    (let [yaml-file (tmp-copy "test/data/structurizr/express/diagram_valid_messy.yaml")
+          invocations (atom 0)
+          f (fn [fp]
+              (try
+                (if (= @invocations 0)
+                  (throw (Exception. "ruh roh"))
+                  (print "doing something..."))
+                (finally
+                  (swap! invocations inc))))
+          watch (delay (e/start f [yaml-file])) ; watch needs to be started inside the with-out-str
+          output (with-out-str
+                   (force watch)
+                   (Thread/sleep 100)
+                   (append yaml-file "ha!\n")
+                   (Thread/sleep 2200)
+                   (append yaml-file "ha!\n")
+                   (Thread/sleep 300))]
+      (e/stop @watch)
+      (is (= 2 @invocations))
+      (is (= 1 (count-substring output "✅")) (str "output: " output))
+      (is (= 1 (count-substring output "🚨")) (str "output: " output))
+      (is (= 3 (count (split-lines output))) (str "output: " output))
+      (delete-file yaml-file))))


### PR DESCRIPTION
This is preparatory refactoring for #168.

As part of #168, we’ll be making the watch a mode that’s composable with
the main features, and we’ll be enabling users to toggle each of the
main features individually. In other words, we have three major
features: `-f`, `-s`, and `-r`. A user can invoke the tool with just one of
those — any one, or with any two of them, or with all three. They can
also optionally add `-w` to have the feature(s) applied in “watch mode”.

This is substantially different than the current paradigm, wherein a
specific and limited set of subcommands trigger a hard-coded “workflow”
or mode of operation.

In order to support the new approach, it is necessary to decouple the
watch feature from edit workflow — essentially, to extract the watch
feature from the edit workflow, and make it a higher-order function so
that it can be composed with any workflow (or featureset, mode of
operation, etc.) That’s what this change does.

Most of the code related to watching is moved from `edit.clj` to `watch.clj`
with minimal modifications. The biggest change is that the watch
workflow can no longer assume that if the function it invokes changes
the file that’d just been changed, that that change would be followed by
a rendering step that’d block for a substantial amount of time — at
least 300ms and often 1000–2500. And therefore we can no longer assume
that when processing subsequent events, that the file will still be in
the active set because it’s being rendered. Therefore I restored the map
in the Hawk “context” value that keeps track of when a file change event
was most recently triggered, for each given file. This had been removed
in a5274963eb because at the time it proved sufficient to simply keep
track of a current-active set and filter by membership in that set.

For more background on how the watch has worked to date, and avoided
duplicative work and infinite loops, see a5274963eb.

Anyway, since the tests now supply processing functions that are
extremely fast, and some of them change the subject file, I needed to
restore the time-based successive-event filtering. I kept the active-set
filtering for now, but I’m not sure it’s still needed. This is pretty
hard to reason about, honestly.