### PR TITLE
Add CLI option --tmp-renderer

### DIFF
--- a/tool/src/main/fc4/io/render.clj
+++ b/tool/src/main/fc4/io/render.clj
@@ -10,7 +10,6 @@
             [fc4.files :refer [remove-extension]]
             [fc4.io.util :refer [binary-spit debug err-msg fail read-text-file]]
             [fc4.io.yaml :as yaml]
-            [fc4.integrations.structurizr.express.node-renderer :refer [->NodeRenderer]]
             [fc4.rendering :as r :refer [render]]
             [fc4.spec :as fs])
   (:import [java.io File FileNotFoundException]))
@@ -98,13 +97,12 @@
   Express diagram definition, rendering it to an image, and writing the image to
   a file in the same directory as the YAML file. Returns the path of the PNG
   file that was written (as a string) or throws an Exception."
-  [in-path]
-  (with-open [renderer (->NodeRenderer)]
-    (let [yaml     (read-text-file in-path)
-          _        (yaml/validate yaml in-path)
-          result   (render renderer yaml)
-          _        (debug (::anom/message result))
-          _        (check result in-path)
-          out-path (yaml-path->png-path in-path)]
-      (binary-spit out-path (::r/png-bytes result))
-      out-path)))
+  [in-path renderer]
+  (let [yaml     (read-text-file in-path)
+        _        (yaml/validate yaml in-path)
+        result   (render renderer yaml)
+        _        (debug (::anom/message result))
+        _        (check result in-path)
+        out-path (yaml-path->png-path in-path)]
+    (binary-spit out-path (::r/png-bytes result))
+    out-path))

--- a/tool/test/fc4/io/render_test.clj
+++ b/tool/test/fc4/io/render_test.clj
@@ -1,6 +1,7 @@
 (ns fc4.io.render-test
   (:require [clojure.java.io      :as jio :refer [delete-file file]]
             [clojure.test         :as ct :refer [deftest is testing]]
+            [fc4.integrations.structurizr.express.chromium-renderer :refer [make-renderer]]
             [fc4.io.render        :as r]
             [fc4.io.util          :as iou :refer [binary-slurp]]
             [fc4.test-utils       :as tu :refer [check]]
@@ -26,7 +27,13 @@
   (System/setProperty "apple.awt.UIElement" "true")
   (require '[image-resizer.core :refer [resize]]))
 
-(reset! iou/debug? true)
+;; TODO: the below seems like a smell. It feels like this state change shouldn’t really be here, in
+;; this specific test namespace, because it’s a global change that impacts any and all behavior
+;; going forward. What happens when someone else working on a different test namespace wants
+;; `debug?` to be `true` whenever those tests are run? So this feels like it should probably be
+;; higher level, at the test-runner or test suite level.
+;; (as pointed out by Jpol here: https://git.io/fjynl )
+(reset! iou/debug? false)
 
 (deftest tmp-png-file (check `r/tmp-png-file))
 
@@ -44,37 +51,38 @@
   0.005)
 
 (deftest render-diagram-file
-  (let [valid        "test/data/structurizr/express/diagram_valid_formatted_snapped.yaml"
-        invalid_a    "test/data/structurizr/express/se_diagram_invalid_a.yaml"
-        invalid_b    "test/data/structurizr/express/se_diagram_invalid_b.yaml"
-        non-existant "test/data/does_not_exist"
-        not-text     "test/data/structurizr/express/diagram_valid_expected.png"]
-    (testing "a YAML file containing a valid SE diagram"
-      (let [expected-out-path (r/yaml-path->png-path valid)
-            expected-bytes (binary-slurp not-text)
-            result (r/render-diagram-file valid)]
-        (is (= result expected-out-path))
-        (is (.canRead (file result)))
-        (let [actual-bytes (binary-slurp result)
-              difference (->> [actual-bytes expected-bytes]
-                              (map bytes->buffered-image)
-                              (map #(resize % 1000 1000))
-                              (reduce image-diff))]
-          (is (<= difference max-allowable-image-difference)))
-        ; cleanup just so as not to leave git status dirty
-        (delete-file result :silently)))
-    (testing "a YAML file containing a blatantly invalid SE diagram"
-      (is (thrown-with-msg? Exception
-                            #"invalid because it is missing the root property"
-                            (r/render-diagram-file invalid_a))))
-    (testing "a YAML file containing a subtly invalid SE diagram"
-      (is (thrown-with-msg? Exception
-                            #"(?s)Errors were found in the diagram definition.+diagram type"
-                            (r/render-diagram-file invalid_b))))
-    (testing "a input file path that does not exist"
-      (is (thrown-with-msg? Exception #"exist" (r/render-diagram-file non-existant))))
-    (testing "a input file that does not contain text"
-      (is (thrown-with-msg?
-           Exception
-           #"(?i)Error.+cursory check.+not a valid Structurizr Express diagram definition"
-           (r/render-diagram-file not-text))))))
+  (with-open [renderer (make-renderer)]
+    (let [valid        "test/data/structurizr/express/diagram_valid_formatted_snapped.yaml"
+          invalid_a    "test/data/structurizr/express/se_diagram_invalid_a.yaml"
+          invalid_b    "test/data/structurizr/express/se_diagram_invalid_b.yaml"
+          non-existant "test/data/does_not_exist"
+          not-text     "test/data/structurizr/express/diagram_valid_expected.png"]
+      (testing "a YAML file containing a valid SE diagram"
+        (let [expected-out-path (r/yaml-path->png-path valid)
+              expected-bytes (binary-slurp not-text)
+              result (r/render-diagram-file valid renderer)]
+          (is (= result expected-out-path))
+          (is (.canRead (file result)))
+          (let [actual-bytes (binary-slurp result)
+                difference (->> [actual-bytes expected-bytes]
+                                (map bytes->buffered-image)
+                                (map #(resize % 1000 1000))
+                                (reduce image-diff))]
+            (is (<= difference max-allowable-image-difference)))
+          ; cleanup just so as not to leave git status dirty
+          (delete-file result :silently)))
+      (testing "a YAML file containing a blatantly invalid SE diagram"
+        (is (thrown-with-msg? Exception
+                              #"invalid because it is missing the root property"
+                              (r/render-diagram-file invalid_a renderer))))
+      (testing "a YAML file containing a subtly invalid SE diagram"
+        (is (thrown-with-msg? Exception
+                              #"(?s)errors were found in the diagram definition.+diagram type"
+                              (r/render-diagram-file invalid_b renderer))))
+      (testing "a input file path that does not exist"
+        (is (thrown-with-msg? Exception #"exist" (r/render-diagram-file non-existant renderer))))
+      (testing "a input file that does not contain text"
+        (is (thrown-with-msg?
+             Exception
+             #"(?i)Error.+cursory check.+not a valid Structurizr Express diagram definition"
+             (r/render-diagram-file not-text renderer)))))))


### PR DESCRIPTION
So as to enable users to opt-in to the experimental (pure Clojure) renderer, as opposed to the default (Node) renderer.

The new renderer itself still has bugs, but that’s expected at this point. In fact, that’s a big motivation for adding this option at this stage: so we can get some help finding bugs.

Closes #159