### PR TITLE
Add performance tests for renderers

### DIFF
--- a/tool/test/fc4/integrations/structurizr/express/chromium_renderer_test.clj
+++ b/tool/test/fc4/integrations/structurizr/express/chromium_renderer_test.clj
@@ -149,6 +149,14 @@
               (is (s/valid? ::r/failure-result result)
                   (expound-str ::r/failure-result result))
               (is (every? #(includes? message %) expected-strings))
-              (is (includes? message "errors were found in the diagram definition")))))))))
+              (is (includes? message "errors were found in the diagram definition")))))))
+    (testing "performance"
+      (let [yaml (slurp (file dir "diagram_valid_formatted_snapped.yaml"))
+            start-ns (System/nanoTime)
+            results (doall (repeatedly 10 #(render renderer yaml)))
+            elapsed-ms (/ (double (- (System/nanoTime) start-ns)) 1000000.0)]
+        (is (<= elapsed-ms 10000))
+        (doseq [result results]
+          (is (s/valid? ::r/success-result result)))))))
 
 (deftest prep-yaml (check `cr/prep-yaml))

--- a/tool/test/fc4/integrations/structurizr/express/node_renderer_test.clj
+++ b/tool/test/fc4/integrations/structurizr/express/node_renderer_test.clj
@@ -97,4 +97,13 @@
               {:keys [::anom/message] :as result} (r/render (->NodeRenderer) input)]
           (is (s/valid? ::r/failure-result result)
               (expound-str ::r/failure-result result))
-          (is (every? #(includes? message %) expected-strings)))))))
+          (is (every? #(includes? message %) expected-strings))))))
+  (testing "performance"
+    (let [yaml (slurp (file dir "diagram_valid_formatted_snapped.yaml"))
+          renderer (->NodeRenderer)
+          start-ns (System/nanoTime)
+          results (doall (repeatedly 10 #(r/render renderer yaml)))
+          elapsed-ms (/ (double (- (System/nanoTime) start-ns)) 1000000.0)]
+      (is (<= elapsed-ms 25000))
+      (doseq [result results]
+        (is (s/valid? ::r/success-result result))))))

--- a/tool/test/fc4/integrations/structurizr/express/node_renderer_test.clj
+++ b/tool/test/fc4/integrations/structurizr/express/node_renderer_test.clj
@@ -104,6 +104,7 @@
           start-ns (System/nanoTime)
           results (doall (repeatedly 10 #(r/render renderer yaml)))
           elapsed-ms (/ (double (- (System/nanoTime) start-ns)) 1000000.0)]
-      (is (<= elapsed-ms 25000))
+      ;; This sometimes takes up to 30 seconds in our CI environment
+      (is (<= elapsed-ms 30000))
       (doseq [result results]
         (is (s/valid? ::r/success-result result))))))


### PR DESCRIPTION
My initial motivation is to ensure that the new Clojure renderer (#155)
is faster than the current Node renderer. Once we decommission the Node
renderer (#163) these tests will serve as regression tests.

Closes #182