### PR TITLE
Change recommended installation method to Homebrew

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ that are relevant only to those working on the framework itself.
 
 Date | Description | PR | Release
 -- | -- | -- | --
+TBD | Recommended installation method changed to Homebrew | TBD | TBD 
 2019-07-26 | New CLI option `--tmp-renderer`  | [#178](https://github.com/FundingCircle/fc4-framework/pull/178) | [2019-07-26_1982](https://github.com/FundingCircle/fc4-framework/releases/tag/release_2019-07-26_1982)
 2019-07-10 | Simplify CLI  | [#177](https://github.com/FundingCircle/fc4-framework/pull/177)  |  [2019-07-10_1868](https://github.com/FundingCircle/fc4-framework/releases/tag/release_2019-07-10_1868)
 2019-04-12 | New CLI subcommands | [#153](https://github.com/FundingCircle/fc4-framework/pull/153) | [2019-04-12_1422](https://github.com/FundingCircle/fc4-framework/releases/tag/release_2019-04-12_1422)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ that are relevant only to those working on the framework itself.
 
 Date | Description | PR | Release
 -- | -- | -- | --
+2019-07-26 | New CLI option `--tmp-renderer`  | [#178](https://github.com/FundingCircle/fc4-framework/pull/178) | [2019-07-26_1982](https://github.com/FundingCircle/fc4-framework/releases/tag/release_2019-07-26_1982)
+2019-07-10 | Simplify CLI  | [#177](https://github.com/FundingCircle/fc4-framework/pull/177)  |  [2019-07-10_1868](https://github.com/FundingCircle/fc4-framework/releases/tag/release_2019-07-10_1868)
 2019-04-12 | New CLI subcommands | [#153](https://github.com/FundingCircle/fc4-framework/pull/153) | [2019-04-12_1422](https://github.com/FundingCircle/fc4-framework/releases/tag/release_2019-04-12_1422)
 2019-03-19 | Fix concurrency bug | [#152](https://github.com/FundingCircle/fc4-framework/pull/152) | [2019-03-19_1389](https://github.com/FundingCircle/fc4-framework/releases/tag/release_2019-03-19_1389)
 2019-03-11 | Fix packaging bug that broke rendering | [#148](https://github.com/FundingCircle/fc4-framework/pull/148) | [2019-03-11_1354](https://github.com/FundingCircle/fc4-framework/releases/tag/release_2019-03-11_1354)

--- a/docs/tool/index.md
+++ b/docs/tool/index.md
@@ -53,6 +53,22 @@ contain the visualization of the diagram.
 
 ## Setup
 
+### Quick start for Homebrew users
+
+If you already use [Homebrew][homebrew], one or both of these commands might be  all you need to get
+started:
+
+```shell
+# If you’re using MacOS and you don’t already have Chromium or Chrome installed:
+brew cask install chromium
+# If you’re using a different OS and you don’t already have Chromium or Chrome installed
+# then install Chromium or Chrome however you generally install such software on your system.
+
+# The main event (should work on any OS that supports Homebrew)
+brew install fundingcircle/floss/fc4
+```
+
+
 ### Requirements
 
 1. A [Java Runtime Environment (JRE)][adoptopenjdk] or [Java Development Kit (JDK)][adoptopenjdk]
@@ -64,15 +80,27 @@ contain the visualization of the diagram.
       1. Chromium/Chrome must be at either `/Applications/Chromium.app` or
          `/Applications/Google Chrome.app`
 
-MacOS quick-start for [Homebrew](https://brew.sh/) users:
-`brew cask install adoptopenjdk11-jre chromium`
 
 
 ### Download and Install
 
+#### With Homebrew
+
+[Homebrew][homebrew] is the recommended installation method for anyone using Linux, MacOS, or
+[Windows Subsystem for Linux][wsl]. Please see [Quick start for Homebrew
+users](#quick-start-for-homebrew-users) above.
+
+If you don’t already use Homebrew, we recommend you install it and then see [Quick start for
+Homebrew users](#quick-start-for-homebrew-users) above.
+
+If you cannot use Homebrew, or would prefer not to, you can [manually](#manually) download and
+install the tool:
+
+#### Manually
+
 1. Download the archive for your platform from [the latest release][latest-release]
 1. Expand the archive
-1. Optional: move the extracted files to somewhere on your $PATH
+1. Optional: move the extracted files to somewhere on your `$PATH`
    1. e.g. `mv ~/Downloads/fc4/fc4* ~/bin/`
 
 
@@ -185,6 +213,8 @@ source code is readily available for review or modification via [its GitHub repo
 [docs-as-code]: https://www.writethedocs.org/guide/docs-as-code/
 [fc4-blog-post]: https://engineering.fundingcircle.com/blog/2018/09/07/the-fc4-framework/
 [floss]: https://en.wikipedia.org/wiki/Free_and_open-source_software
+[homebrew]: https://brew.sh/
 [latest-release]: https://github.com/FundingCircle/fc4-framework/releases/latest
 [repo]: https://github.com/FundingCircle/fc4-framework
 [structurizr-express]: https://structurizr.com/help/express
+[wsl]: https://docs.microsoft.com/en-us/windows/wsl/about

--- a/tool/doc/examples/docker-install-and-render/Dockerfile
+++ b/tool/doc/examples/docker-install-and-render/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get -yq update \
 
 # Install fc4-tool
 RUN curl -L -s \
-      https://github.com/FundingCircle/fc4-framework/releases/download/release_2018-12-11_772/fc4-tool-linux-d021ef9.tar.gz \
+      https://github.com/FundingCircle/fc4-framework/releases/download/release_2019-07-26_1982/fc4-tool-linux-amd64-bc5542c.tar.gz \
       | tar xzv
 
 COPY *.yaml ./
 
-RUN fc4/fc4 render *.yaml
+RUN fc4/fc4 --render *.yaml


### PR DESCRIPTION
We just published a [Homebrew Tap][1] for Funding Circle’s FLOSS tools and [that tap][2] includes a formula for fc4-tool.

This is great because not only does it make it _way_ easier to install the fc4 tool, it also makes it _much_ more likely that users will install updates!

(This _might_ also enable us to get ahold of some download/install stats, but that might require contributing a formula to homebrew-core; I’m not sure.)

[1]: https://docs.brew.sh/Taps
[2]: https://github.com/FundingCircle/homebrew-floss