### PR TITLE
Add Developer Certificate of Origin and accept contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,9 @@ collaboratively over time.
 
 For more information and to get started using FC4, see [the website][website].
 
-## Contributing
+## Feedback and Contributions
 
-* We cannot currently accept contributions of code or documentation, but we’re working on it.
-* Any and all feedback — questions, suggestions, bug reports, experience reports, etc — would be
-  greatly appreciated! Please [create an issue][new-issue] and one of the maintainers will get back
-  to you shortly.
+Contributions — including any and all feedback — are welcome and greatly appreciated! Please see [Contributing](contributing.md).
 
 ## Copyright & License
 
@@ -20,5 +17,4 @@ Copyright © 2018–2019 Funding Circle Ltd.
 Distributed under [the BSD 3-Clause License](LICENSE).
 
 [docs-as-code]: https://www.writethedocs.org/guide/docs-as-code/
-[new-issue]: https://github.com/FundingCircle/fc4-framework/issues/new
 [website]: https://fundingcircle.github.io/fc4-framework/

--- a/bin/lint-markdown
+++ b/bin/lint-markdown
@@ -2,4 +2,4 @@
 
 # NB: this is intended to be invoked from the root of the repo.
 
-mdl --style .mdstyle.rb docs proposals README.md tool/README.md
+mdl --style .mdstyle.rb ./*.md tool/*.md docs proposals

--- a/bin/lint-prose
+++ b/bin/lint-prose
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-vale --no-wrap docs proposals README.md tool/README.md
+vale --no-wrap ./*.md tool/*.md docs proposals

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,71 @@
+# Contributing to the FC4 Framework
+
+Contributions — including any and all feedback — are welcome and greatly appreciated!
+
+
+## Feedback
+
+Any and all feedback — questions, suggestions, bug reports, experience reports, etc — would be
+greatly appreciated! Please [create an issue][new-issue] and one of the maintainers will get back to
+you shortly.
+
+[new-issue]: https://github.com/FundingCircle/fc4-framework/issues/new
+
+
+## Code and Documentation
+
+If you wish to contribute code and/or documentation changes (which would be fantastic) you must:
+
+* Read and agree to the _Developer Certificate of Origin_ below
+* Include this statement in each commit message:
+
+  ```text
+  This change is authored by and contributed to the FC4 Framework by
+  Random J Developer <random@developer.example.org> who hereby certifies
+  each statement included in the project’s Developer Certificate of
+  Origin located at https://git.io/fj53J
+  ```
+
+  using your real name and email address.
+
+### Developer Certificate of Origin
+
+```text
+Developer Certificate of Origin
+Version 1.1
+
+Copyright © 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I have the right
+    to submit it under the open source license indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best of my
+    knowledge, is covered under an appropriate open source license and I have
+    the right under that license to submit that work with modifications, whether
+    created in whole or in part by me, under the same open source license
+    (unless I am permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other person who
+    certified (a), (b) or (c) and I have not modified it.
+
+(d) I understand and agree that this project and the contribution are public and
+    that a record of the contribution (including all personal information I
+    submit with it, including my sign-off) is maintained indefinitely and may be
+    redistributed consistent with this project or the open source license(s)
+    involved.
+```
+
+### License
+
+All contributions to this project are licensed under [the project’s license](LICENSE).


### PR DESCRIPTION
I’d thought that internally within Funding Circle we (Product Engineering) were still working with Legal to figure out our guidelines for accepting contributions. But then I recently discovered that  one of our projects ([Jackdaw](https://github.com/FundingCircle/jackdaw/blob/master/CONTRIBUTING.md)) recently started accepting contributions. So I basically just copied these guidelines from that project.