### PR TITLE
Improve tool versioning scheme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ jobs:
            name: Create distribution packages
            command: |
              export GIT_HEAD_SHA=$(git rev-parse --short HEAD)
+             export FC4_VERSION="$(date "+%Y.%m.%d")-${GIT_HEAD_SHA}" # required by pkg-all
              bin/pkg-all
              mkdir -p ~/workspace/packages
              mv target/pkg/*.gz ~/workspace/packages/
@@ -137,7 +138,9 @@ jobs:
            command: |
              if [[ $CIRCLE_BRANCH == "master" ]]; then
                # Tag has build num suffix in case we do multiple releases on a given day.
-               TAG="release_$(date "+%Y-%m-%d")_${CIRCLE_BUILD_NUM}"
+               GIT_HEAD_SHA=$(git rev-parse --short HEAD)
+               VERSION="$(date "+%Y.%m.%d")-${GIT_HEAD_SHA}"
+               TAG="release_${VERSION}"
              else
                # We need this to be the same across all builds for a branch so we only ever keep the
                # latest tag+release for a given branch, or we’d have way too many tags+branches.

--- a/tool/bin/pkg-all
+++ b/tool/bin/pkg-all
@@ -2,7 +2,7 @@
 ## Run this from <project-root>/tool/
 set -e
 
-[[ -z "$GIT_HEAD_SHA" ]] && echo 'GIT_HEAD_SHA is not set!' && exit 1
+[[ -z "$FC4_VERSION" ]] && echo 'FC4_VERSION is not set!' && exit 1
 
 # TODO: how risky is this, that we’ll end up packaging stale files? I think not *too* risky since
 # we *should* be running this script in a fresh CI container!
@@ -21,7 +21,7 @@ for os in macos linux; do
   cp ../docs/tool/index.md $pkg_dir/README.md
   cp "target/pkg/renderer/render-$os" $pkg_dir/fc4-render
 
-  archive="fc4-tool-$os-amd64-$GIT_HEAD_SHA.tar.gz"
+  archive="fc4-tool-$os-amd64-$FC4_VERSION.tar.gz"
   echo "  Building archive target/pkg/$archive..."
   (cd $os_dir && tar -czf "../$archive" fc4/*)
 done


### PR DESCRIPTION
As per #193.

In addition to hopefully making the Homebrew formula pass `brew audit` ([1](https://github.com/FundingCircle/homebrew-floss/pull/4#issuecomment-521201976)), this may help address https://github.com/FundingCircle/homebrew-floss/issues/6 and https://github.com/FundingCircle/homebrew-floss/issues/7