### PR TITLE
Small code cleanup related to setting a system property

### DIFF
--- a/tool/deps.edn
+++ b/tool/deps.edn
@@ -55,7 +55,10 @@
                            ; We’ve found that some Linux systems seem to default to US-ASCII which
                            ; will generally break the ability of the main program to properly parse
                            ; the error output of the renderer.
-                           :jvm-opts    ["-Dfile.encoding=UTF8"]}
+                           :jvm-opts    ["-Dfile.encoding=UTF8"
+                                         ; Prevent the Java app icon from popping up and grabbing
+                                         ; focus on MacOS.
+                                         "-Dapple.awt.UIElement=true"]}
 
            :test/run      {:main-opts   ["-m" "fc4.test-runner.runner"]}
 
@@ -68,7 +71,10 @@
                                          "--codecov"]}
 
            ;; Enables running from source:
-           :main          {:main-opts   ["-m" "fc4.io.cli.main"]}
+           :main          {:main-opts   ["-m" "fc4.io.cli.main"]
+                                         ; Prevent the Java app icon from popping up and grabbing
+                                         ; focus on MacOS.
+                           :jvm-opts    ["-Dapple.awt.UIElement=true"]}
 
            :kibit         {:extra-deps  {jonase/kibit               {:mvn/version "0.1.6"}}
                            :main-opts   ["-e"

--- a/tool/dist/fc4
+++ b/tool/dist/fc4
@@ -7,12 +7,17 @@ set -e
 
 SCRIPT_DIR="${BASH_SOURCE%/*}"
 
+JVM_OPTS=()
+
 # It’s crucial to ensure that the JVM’s default character encoding is UTF-8
-# because the renderer outputs UTF-8 encoded text to its stderr, which the main
+# because the Node renderer outputs UTF-8 encoded text to its stderr, which the main
 # program (the JVM program) then needs to read correctly. We’ve found that some
 # Linux systems seem to default to US-ASCII which will generally break the
 # ability of the main program to properly parse the error output of the
 # renderer.
-JVM_OPTS="-Dfile.encoding=UTF8"
+JVM_OPTS+=("-Dfile.encoding=UTF8")
 
-java "$JVM_OPTS" -jar "$SCRIPT_DIR/fc4.jar" "$@"
+# Prevent the Java app icon from popping up and grabbing focus on MacOS.
+JVM_OPTS+=("-Dapple.awt.UIElement=true")
+
+java "${JVM_OPTS[@]}" -jar "$SCRIPT_DIR/fc4.jar" "$@"

--- a/tool/src/main/fc4/image_utils.clj
+++ b/tool/src/main/fc4/image_utils.clj
@@ -1,20 +1,15 @@
 (ns fc4.image-utils
   (:require [clojure.string :refer [starts-with?]])
-  (:import [java.io ByteArrayInputStream ByteArrayOutputStream]
+  (:import [java.awt Image]
+           [java.awt.image BufferedImage]
+           [java.io ByteArrayInputStream ByteArrayOutputStream]
            [java.util Base64]
            [javax.imageio ImageIO]))
 
 ;; Some of the functions include some type hints or type casts. These are to prevent reflection, but
-;; not for the usual reason of improving performance. In this case, some of the reflection leads to
-;; classes that violate some kind of boundary introduced in Java 9/10/11 and yield an ominous
-;; message printed to stdout (or maybe stderr).
-
-;; Import various Java AWT classes that we need to work with the images — but first set a system
-;; property that will prevent the Java app icon from popping up and grabbing focus on MacOS. That is
-;; why these imports are here rather that in the ns form.
-(System/setProperty "apple.awt.UIElement" "true")
-(import '[java.awt Image]
-        '[java.awt.image BufferedImage])
+;; not for the usual reason of improving performance. In this case, some of the reflection violates
+;; the module boundary rules introduced in Java 9/10/11(?) and yield an ominous message printed to
+;; stdout (or maybe stderr).
 
 (defn bytes->buffered-image ^BufferedImage [bytes]
   (ImageIO/read (ByteArrayInputStream. bytes)))

--- a/tool/src/main/fc4/integrations/structurizr/express/chromium_renderer.clj
+++ b/tool/src/main/fc4/integrations/structurizr/express/chromium_renderer.clj
@@ -10,19 +10,14 @@
             [fc4.io.util :refer [debug? debug]]
             [fc4.rendering :as r :refer [Renderer]]
             [fc4.util :refer [fault namespaces qualify-keys with-timeout]]
-            [fc4.yaml :as yaml]))
+            [fc4.yaml :as yaml])
+  (:import [java.awt Color Font Image RenderingHints]
+           [java.awt.image BufferedImage]))
 
 ;; Some of the functions include some type hints or type casts. These are to prevent reflection, but
 ;; not for the usual reason of improving performance. In this case, some of the reflection leads to
 ;; classes that violate some kind of boundary introduced in Java 9/10/11 and yield an ominous
 ;; message printed to stdout (or maybe stderr).
-
-;; Import various Java AWT classes that we need to work with the images — but first set a system
-;; property that will prevent the Java app icon from popping up and grabbing focus on MacOS. That is
-;; why these imports are here rather that in the ns form.
-(System/setProperty "apple.awt.UIElement" "true")
-(import '[java.awt Color Font Image RenderingHints]
-        '[java.awt.image BufferedImage])
 
 ;; Configure Jetty logging so that log messages are not output to stderr, distracting the CLI UX.
 ;; (clj-chrome-devtools uses Jetty’s WebSocket client, via gniazdo, to communicate with Chromium.)

--- a/tool/test/fc4/integrations/structurizr/express/chromium_renderer_test.clj
+++ b/tool/test/fc4/integrations/structurizr/express/chromium_renderer_test.clj
@@ -10,6 +10,7 @@
             [clojure.test :refer [deftest testing is]]
             [cognitect.anomalies :as anom]
             [expound.alpha :as expound :refer [expound-str]]
+            [image-resizer.core :refer [resize]]
 
             ; I’d prefer to use Orchestra but it’s not quite working right now. TODO.
             ;[orchestra.spec.test :as stest]
@@ -26,25 +27,6 @@
      (map symbol)
      (stest/instrument))
 (set! s/*explain-out* expound/printer)
-
-; Require image-resizer.core while preventing the Java app icon from popping up
-; and grabbing focus on MacOS.
-; Approach found here: https://stackoverflow.com/questions/17460777/stop-java-coffee-cup-icon-from-appearing-in-the-dock-on-mac-osx/17544259#comment48475681_17544259
-; This require is here rather than in the ns form at the top of the file because
-; if I include this ns in the require list in the ns form, then the only way to
-; suppress the app icon from popping up and grabbing focus would be to place the
-; System/setProperty call at the top of the file, before the ns form, and that’d
-; violate Clojure idioms. When people open a clj file, they expect to see a ns
-; form right at the top declaring which namespace the file defines and
-; populates.
-; To be clear, calling the `require` function in a clj file, to require a
-; dependency, outside of the ns form, is *also* non-idiomatic; people expect all
-; of the dependencies of a file to be listed in the ns form. So I had to choose
-; between two non-idiomatic solutions; I chose this one because it seems to me
-; to be slightly less jarring for Clojurists.
-(do
-  (System/setProperty "apple.awt.UIElement" "true")
-  (require '[image-resizer.core :refer [resize]]))
 
 (def max-allowable-image-difference
   ;; This threshold might seem low, but the diffing algorithm is

--- a/tool/test/fc4/integrations/structurizr/express/node_renderer_test.clj
+++ b/tool/test/fc4/integrations/structurizr/express/node_renderer_test.clj
@@ -8,26 +8,8 @@
             [clojure.string :refer [includes?]]
             [clojure.test :refer [deftest testing is]]
             [cognitect.anomalies :as anom]
-            [expound.alpha :as expound :refer [expound-str]]))
-
-; Require image-resizer.core while preventing the Java app icon from popping up
-; and grabbing focus on MacOS.
-; Approach found here: https://stackoverflow.com/questions/17460777/stop-java-coffee-cup-icon-from-appearing-in-the-dock-on-mac-osx/17544259#comment48475681_17544259
-; This require is here rather than in the ns form at the top of the file because
-; if I include this ns in the require list in the ns form, then the only way to
-; suppress the app icon from popping up and grabbing focus would be to place the
-; System/setProperty call at the top of the file, before the ns form, and that’d
-; violate Clojure idioms. When people open a clj file, they expect to see a ns
-; form right at the top declaring which namespace the file defines and
-; populates.
-; To be clear, calling the `require` function in a clj file, to require a
-; dependency, outside of the ns form, is *also* non-idiomatic; people expect all
-; of the dependencies of a file to be listed in the ns form. So I had to choose
-; between two non-idiomatic solutions; I chose this one because it seems to me
-; to be slightly less jarring for Clojurists.
-(do
-  (System/setProperty "apple.awt.UIElement" "true")
-  (require '[image-resizer.core :refer [resize]]))
+            [expound.alpha :as expound :refer [expound-str]]
+            [image-resizer.core :refer [resize]]))
 
 (def max-allowable-image-difference
   ;; This threshold might seem low, but the diffing algorithm is

--- a/tool/test/fc4/io/cli/main_test.clj
+++ b/tool/test/fc4/io/cli/main_test.clj
@@ -10,26 +10,8 @@
             [fc4.io.util :as iou :refer [binary-slurp]]
             [fc4.test-utils.image-diff :refer [bytes->buffered-image image-diff]]
             [fc4.test-utils.io :refer [tmp-copy]]
-            [fc4.yaml :as fy :refer [assemble split-file]]))
-
-; Require image-resizer.core while preventing the Java app icon from popping up
-; and grabbing focus on MacOS.
-; Approach found here: https://stackoverflow.com/questions/17460777/stop-java-coffee-cup-icon-from-appearing-in-the-dock-on-mac-osx/17544259#comment48475681_17544259
-; This require is here rather than in the ns form at the top of the file because
-; if I include this ns in the require list in the ns form, then the only way to
-; suppress the app icon from popping up and grabbing focus would be to place the
-; System/setProperty call at the top of the file, before the ns form, and that’d
-; violate Clojure idioms. When people open a clj file, they expect to see a ns
-; form right at the top declaring which namespace the file defines and
-; populates.
-; To be clear, calling the `require` function in a clj file, to require a
-; dependency, outside of the ns form, is *also* non-idiomatic; people expect all
-; of the dependencies of a file to be listed in the ns form. So I had to choose
-; between two non-idiomatic solutions; I chose this one because it seems to me
-; to be slightly less jarring for Clojurists.
-(do
-  (System/setProperty "apple.awt.UIElement" "true")
-  (require '[image-resizer.core :refer [resize]]))
+            [fc4.yaml :as fy :refer [assemble split-file]]
+            [image-resizer.core :refer [resize]]))
 
 (defmacro with-err-str
   "Evaluates exprs in a context in which *err* is bound to a fresh

--- a/tool/test/fc4/io/render_test.clj
+++ b/tool/test/fc4/io/render_test.clj
@@ -6,26 +6,8 @@
             [fc4.io.util          :as iou :refer [binary-slurp]]
             [fc4.test-utils       :as tu :refer [check]]
             [fc4.test-utils.image-diff :refer [bytes->buffered-image image-diff]]
-            [fc4.util :as fu]))
-
-; Require image-resizer.core while preventing the Java app icon from popping up
-; and grabbing focus on MacOS.
-; Approach found here: https://stackoverflow.com/questions/17460777/stop-java-coffee-cup-icon-from-appearing-in-the-dock-on-mac-osx/17544259#comment48475681_17544259
-; This require is here rather than in the ns form at the top of the file because
-; if I include this ns in the require list in the ns form, then the only way to
-; suppress the app icon from popping up and grabbing focus would be to place the
-; System/setProperty call at the top of the file, before the ns form, and that’d
-; violate Clojure idioms. When people open a clj file, they expect to see a ns
-; form right at the top declaring which namespace the file defines and
-; populates.
-; To be clear, calling the `require` function in a clj file, to require a
-; dependency, outside of the ns form, is *also* non-idiomatic; people expect all
-; of the dependencies of a file to be listed in the ns form. So I had to choose
-; between two non-idiomatic solutions; I chose this one because it seems to me
-; to be slightly less jarring for Clojurists.
-(do
-  (System/setProperty "apple.awt.UIElement" "true")
-  (require '[image-resizer.core :refer [resize]]))
+            [fc4.util :as fu]
+            [image-resizer.core :refer [resize]]))
 
 ;; TODO: the below seems like a smell. It feels like this state change shouldn’t really be here, in
 ;; this specific test namespace, because it’s a global change that impacts any and all behavior


### PR DESCRIPTION
I happened to be scrolling by this code and had a sudden epiphany that
I could just set this system property when launching the JVM instead of
in the code before requiring/importing certain libraries/classes.

So, if this works, this should be nice.

Just for reference, I found this approach to preventing the Java app
icon from popping up and grabbing focus on MacOS [here](https://stackoverflow.com/questions/17460777/stop-java-coffee-cup-icon-from-appearing-in-the-dock-on-mac-osx/17544259#comment48475681_17544259).