### PR TITLE
Fix the CI job that publishes the packages…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
        - run:
            name: Create distribution packages
            command: |
-             export GIT_HEAD_SHA=$(git rev-parse --short HEAD)
+             export GIT_HEAD_SHA=${CIRCLE_SHA1:0:7}
              export FC4_VERSION="$(date "+%Y.%m.%d")-${GIT_HEAD_SHA}" # required by pkg-all
              bin/pkg-all
              mkdir -p ~/workspace/packages
@@ -138,7 +138,7 @@ jobs:
            command: |
              if [[ $CIRCLE_BRANCH == "master" ]]; then
                # Tag has build num suffix in case we do multiple releases on a given day.
-               GIT_HEAD_SHA=$(git rev-parse --short HEAD)
+               GIT_HEAD_SHA=${CIRCLE_SHA1:0:7}
                VERSION="$(date "+%Y.%m.%d")-${GIT_HEAD_SHA}"
                TAG="release_${VERSION}"
              else


### PR DESCRIPTION
…the distribution packages for new releases, that is.

This was broken by #199, and we didn’t know it was broken until after we
merged because this job is only run on master.

The reason it failed is because this job doesn’t include a checkout
step, so `git rev-parse` was failing with fatal: Not a git repository
because the dir `.git` wasn’t present.

Example of a failed job:
  https://app.circleci.com/jobs/github/FundingCircle/fc4-framework/2564

I could have fixed this by adding the checkout step to the job, but that
would have made it slower. I chose instead to use the CIRCLE_SHA1
environment variable, shortened to 7 chars; this results in the same
value as `git rev-parse --short HEAD`.

I also changed the job that creates the distribution packages to use the
same expression, for consistency. It’s unlikely, but the behavior of
`git rev-parse --short` *could* change.