### PR TITLE
Update deps and CI environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,20 +7,18 @@ version: 2
 # steps *except* `checkout` to be a subdirectory of the project — because by
 # default, `checkout` checks out into the specified `working_directory`. I found
 # this solution here: https://stackoverflow.com/a/50570581/7012
-tool_job_defaults: &tool_job_defaults
-  working_directory: ~/project/tool
-  docker:
-      # See https://circleci.com/docs/2.0/circleci-images/
-    - image: circleci/clojure:openjdk-11-tools-deps-browsers
 
 jobs:
    tool_test:
-     <<: *tool_job_defaults
+     docker:    # See https://circleci.com/docs/2.0/circleci-images/
+       - image: circleci/openjdk:11-stretch-browsers
+     working_directory: ~/project/tool
      steps:
        - checkout: {path: ~/project}
        - restore_cache:
            keys:
              - test-deps-v1-{{checksum "deps.edn"}}-{{checksum "bin/download-test-deps"}}
+       - run: bin/install-clojure
        - run: bin/download-test-deps
        - run: bin/tests-with-coverage
        - save_cache:
@@ -35,7 +33,9 @@ jobs:
           command: bash <(curl -s https://codecov.io/bash) || echo Codecov upload failed
 
    tool_clj_lint:
-     <<: *tool_job_defaults
+     docker:    # See https://circleci.com/docs/2.0/circleci-images/
+       - image: circleci/clojure:tools-deps
+     working_directory: ~/project/tool
      steps:
        - checkout: {path: ~/project}
        - restore_cache: {keys: ['clj-lint-deps-v1-{{checksum "deps.edn"}}']}
@@ -47,7 +47,9 @@ jobs:
    # Kibit is is a static code analyzer for Clojure. It searches for patterns of code that could be
    # rewritten with a more idiomatic style. https://github.com/jonase/kibit
    tool_kibit:
-     <<: *tool_job_defaults
+     docker:    # See https://circleci.com/docs/2.0/circleci-images/
+       - image: circleci/clojure:tools-deps
+     working_directory: ~/project/tool
      steps:
        - checkout: {path: ~/project}
        - restore_cache: {keys: ['kibit-deps-v1-{{checksum "deps.edn"}}']}
@@ -57,12 +59,15 @@ jobs:
           paths: [.cpcache, ~/.m2, ~/.gitlibs]
 
    tool_build_dist_pkg:
-     <<: *tool_job_defaults
+     docker:
+       - image: circleci/openjdk:11-stretch
+     working_directory: ~/project/tool
      steps:
        - checkout: {path: ~/project}
        - restore_cache:
            keys:
              - pkg-deps-v1-{{checksum "deps.edn"}}-{{checksum "bin/download-pkg-deps"}}
+       - run: bin/install-clojure
        - run: bin/download-pkg-deps
        - run:
            name: Create distribution package
@@ -80,11 +85,8 @@ jobs:
 
    tool_test_dist_pkg:
      docker:
-       # The test renders failed (Chrome crashed) when we used the tag `11-browsers` tag but succeed
-       # when we use `11-stretch-browsers` — not sure why. Debian and Chrome are both a little newer
-       # (as of this writing) in the `-stretch-` tag so that probably accounts for it.
        - image: circleci/openjdk:11-stretch-browsers
-     working_directory: ~/test/test-renders # overrides the value in tool_job_defaults.
+     working_directory: ~/test/test-renders
      steps:
        - checkout: {path: ~/project} # only so we can access the test diagram YAML file
        - attach_workspace: {at: ~/workspace} # so we can access the distribution package that was built in tool_build_dist_pkg
@@ -106,7 +108,7 @@ jobs:
        # was failing. (There’s a good chance any circleci image using Debian would work, but I
        # figure we may as well use the same one as we’ve already used in a few prior jobs, because
        # there’s a decent chance (I’d think) that its layers will already be cached.)
-       - image: circleci/openjdk:11-stretch-browsers
+       - image: circleci/openjdk:11-stretch
      steps:
        - attach_workspace: {at: ~/workspace}
        - run: |

--- a/tool/Dockerfile.pkg
+++ b/tool/Dockerfile.pkg
@@ -1,7 +1,7 @@
 # This Dockerfile is intended for building distribution packages/artifacts.
 
 # This base image is documented here: https://circleci.com/docs/2.0/circleci-images/
-FROM circleci/clojure:openjdk-11-tools-deps
+FROM circleci/openjdk:11-stretch
 
 # We need to create the working dir explicitly via mkdir, rather than just let WORKDIR create it
 # (or it might actually be created lazily by e.g. COPY) because if we let WORKDIR (or maybe COPY)
@@ -12,6 +12,10 @@ RUN mkdir /home/circleci/tool && chown -R circleci:circleci /home/circleci
 USER circleci
 
 WORKDIR /home/circleci/tool
+
+# Install Clojure
+COPY bin/install-clojure /home/circleci/
+RUN /home/circleci/install-clojure
 
 # Download the deps separately from and prior to copying the app code so that we don’t have to
 # re-download deps every time the app code changes.

--- a/tool/Dockerfile.test
+++ b/tool/Dockerfile.test
@@ -7,17 +7,21 @@
 # * but it does requires access to your files.
 
 # This base image is documented here: https://circleci.com/docs/2.0/circleci-images/
-FROM circleci/clojure:openjdk-11-tools-deps-browsers
+FROM circleci/openjdk:11-stretch-browsers
 
 # We need to create the working dir explicitly via mkdir, rather than just let WORKDIR create it
 # (or it might actually be created lazily by e.g. COPY) because if we let WORKDIR (or maybe COPY)
 # create it, it gets created via root with the wrong permissions and then the user that’s used for
 # all the RUN commands (circleci) can’t write to it. This is *really* annoying.
 USER root
-RUN mkdir /home/circleci/tool && chown circleci:circleci /home/circleci/tool
+RUN mkdir -p /home/circleci/tool && chown -R circleci:circleci /home/circleci
 USER circleci
 
 WORKDIR /home/circleci/tool
+
+# Install Clojure
+COPY bin/install-clojure /home/circleci/
+RUN /home/circleci/install-clojure
 
 # Download the deps separately from and prior to copying the app code so that we don’t have to
 # re-download deps every time the app code changes.

--- a/tool/bin/install-clojure
+++ b/tool/bin/install-clojure
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eux -o pipefail
+
+# Steps copied from https://clojure.org/guides/getting_started#_installation_on_linux
+curl -O https://download.clojure.org/install/linux-install-1.10.1.469.sh
+chmod +x linux-install-1.10.1.469.sh
+sudo ./linux-install-1.10.1.469.sh

--- a/tool/deps.edn
+++ b/tool/deps.edn
@@ -13,7 +13,8 @@
  {org.clojure/clojure         {:mvn/version "1.10.1"}
   org.clojure/spec.alpha      {:mvn/version "0.2.176"}
   org.clojure/tools.cli       {:mvn/version "0.4.2"}
-  clj-chrome-devtools         {:mvn/version "20190601"}
+  clj-chrome-devtools         {:git/url "https://github.com/tatut/clj-chrome-devtools"
+                               :sha "58a396f54f469e98b5aae92b9357d65434914228"}
   clj-commons/clj-yaml        {:mvn/version "0.7.0"}
   expound                     {:mvn/version "0.7.2"}
   com.cognitect/anomalies     {:mvn/version "0.1.12"}
@@ -25,17 +26,17 @@
   ;; to fail. I’m overriding the dependency here at the root level, which takes precedence over the
   ;; profiles, because I want to ensure that we’ll use the same version of joda-time when running
   ;; the tests and building a distribution package (uberjar).
-  joda-time/joda-time {:mvn/version "2.10.2"}
+  joda-time/joda-time {:mvn/version "2.10.3"}
 
   ;; Conflicting versions of jna are resolved via org.clojure/tools.gitlibs and hawk.
-  net.java.dev.jna/jna          {:mvn/version "5.3.1"}
-  net.java.dev.jna/jna-platform {:mvn/version "5.3.1"}
+  net.java.dev.jna/jna          {:mvn/version "5.4.0"}
+  net.java.dev.jna/jna-platform {:mvn/version "5.4.0"}
 
   ;; test.chuck is in the main dependency list, rather than in the test profile,
   ;; because we’re using one of its generators in a spec in a source file.
   ;; This means we’ll also need org.clojure/test.check at runtime. Not ideal,
   ;; but worth it.
-  com.gfredericks/test.chuck {:mvn/version "0.2.9"}}
+  com.gfredericks/test.chuck {:mvn/version "0.2.10"}}
 
  :aliases {:dev           {:extra-deps  {org.clojure/tools.trace    {:mvn/version "0.7.9"}
                                          inspectable                {:mvn/version "0.2.2"}}
@@ -45,8 +46,8 @@
            :repl          {:jvm-opts    ["-Dclojure.server.repl={:port,5555,:accept,clojure.core.server/repl}"]}
 
            :test          {:extra-paths ["test" "src/test_utils"]
-                           :extra-deps  {org.clojure/test.check     {:mvn/version "0.10.0-alpha3"}
-                                         eftest                     {:mvn/version "0.5.4"}
+                           :extra-deps  {org.clojure/test.check     {:mvn/version "0.10.0"}
+                                         eftest                     {:mvn/version "0.5.8"}
                                          orchestra                  {:mvn/version "2018.12.06-2"}
                                          image-resizer              {:mvn/version "0.1.10"}}
                            ; It’s crucial to ensure that the JVM’s default character encoding is
@@ -62,7 +63,7 @@
 
            :test/run      {:main-opts   ["-m" "fc4.test-runner.runner"]}
 
-           :test/coverage {:extra-deps  {cloverage                  {:mvn/version "1.0.13"}}
+           :test/coverage {:extra-deps  {cloverage                  {:mvn/version "1.1.1"}}
                            :main-opts   ["-m" "cloverage.coverage"
                                          "--src-ns-path" "src/main"
                                          "--test-ns-path" "test"
@@ -76,11 +77,13 @@
                                          ; focus on MacOS.
                            :jvm-opts    ["-Dapple.awt.UIElement=true"]}
 
-           :kibit         {:extra-deps  {jonase/kibit               {:mvn/version "0.1.6"}}
+           ; Do NOT upgrade kibit past 0.1.6 until this bug is fixed: https://git.io/Je3vB as it
+           ; makes kibit nearly useless for this project.
+           :kibit         {:extra-deps  {jonase/kibit {:mvn/version "0.1.6"}}
                            :main-opts   ["-e"
                                          "(require,'[kibit.driver,:as,k]),(k/external-run,[\"src\"],nil)"]}
 
-           :lint          {:extra-deps  {cljfmt                     {:mvn/version "0.6.3"}
+           :lint          {:extra-deps  {cljfmt                     {:mvn/version "0.6.4"}
                                          github-JamesLaverack/cljfmt-runner
                                          {:git/url "https://github.com/JamesLaverack/cljfmt-runner"
                                           :sha     "97960e9a6464935534b5a6bab529e063d0027128"}}
@@ -88,12 +91,14 @@
 
            :lint/fix      {:main-opts   ["-m" "cljfmt-runner.fix"]}
 
-           :uberjar       {:extra-deps  {luchiniatwork/cambada      {:mvn/version "1.0.0"}}
+           :uberjar       {:extra-deps  {mikeananev/cambada {:git/url "https://github.com/mikeananev/cambada"
+                                                             :sha "359670a68961b1fcbaea6a3a7311c38ae524cbc9"}}
                            :main-opts   ["-m" "cambada.uberjar"
                                          "-m" "fc4.io.cli.main"
                                          "--aot" "all"
                                          "--no-copy-source"
                                          "--out" "target"]}
 
-           :outdated      {:extra-deps  {olical/depot               {:mvn/version "1.2.0"}}
+           :outdated      {:extra-deps  {olical/depot {:git/url "https://github.com/Olical/depot.git"
+                                                       :sha "309525c33a204f469ef420e3bfd02b5100439d63"}}
                            :main-opts   ["-m" "depot.outdated.main"]}}}


### PR DESCRIPTION
At first I thought this was going to be simply bumping a few version
numbers, which I do occasionally as a matter of course.

Then I recalled that [a change][1] had recently been made to
clj-chrome-devtools that would enable it to be included as a gitlib
rather than a Maven artifact. I much prefer gitlibs, so I switched it.
Well, that lead to a cascade of changes.

First I ran into [this bug in tools.deps][2] that broke pretty much
everything — but only in CI, not locally. It was pointed out to me in
Clojurians that that bug had already been fixed, so I figured that I
must be using an out-of-date version of Clojure in CI. Sure enough, the
CircleCI Clojure images are fairly out of date and don’t include that
bugfix.

I worked around that by switching from CircleCI’s Clojure images to
CircleCI’s OpenJDK images, and installing the latest (as of this
writing) version of Clojure as a step in the jobs that require run the
project’s code (as opposed to e.g. linting-type jobs that only analyze
the code).

So then the tests passed, but packaging was failing. Turns out I ran
into [another bug related to gitlibs][3], this time in the packaging
tool we’re using, Cambada. I was able to work around this bug by
switching to a fork of Cambada, which seems like a good move anyway
because the “root” Cambada repo seems to be unmaintained.

I _think_ that explains everything, but please let me know if I missed
anything.

[1]: https://github.com/tatut/clj-chrome-devtools/issues/21#issuecomment-520040669
[2]: https://clojure.atlassian.net/browse/TDEPS-52
[3]: https://github.com/luchiniatwork/cambada/issues/9