### PR TITLE
Add some GitHub Actions CI Workflows

### DIFF
--- a/.github/workflows/code-push.yaml
+++ b/.github/workflows/code-push.yaml
@@ -1,0 +1,67 @@
+name: Code Push
+
+on:
+  push:
+    branches:
+      - '*' # prevents workflow from being triggered by pushing/creating tags
+    paths:
+      - 'tool/**'
+      - '.github/workflows/code-push.yaml'
+
+# Some of the jobs below include a step named “Permissions workaround”. To explain:
+#
+# This section of this page:
+# https://help.github.com/en/articles/virtual-environments-for-github-actions#docker-container-filesystem
+# contains this note:
+#
+# > GitHub Actions must be run by the default Docker user (root). Ensure your Dockerfile does not
+# > set the USER instruction, otherwise you will not be able to access GITHUB_WORKSPACE.
+#
+# Unfortunately the images we’re using violate this advice — they include `USER circleci`.
+#
+# So this step is an attempt to ensure that the user `circleci` will be able to write to the dirs to
+# which it needs to write. I guess it’s a hack or a band-aid or whatever, but it does seem to work.
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        java-version: ['9', '11']
+      fail-fast: false
+    runs-on: ubuntu-latest
+    container: circleci/openjdk:${{ matrix.java-version }}-browsers
+    steps:
+      - uses: actions/checkout@v1
+      - name: Permissions workaround
+        run: 'sudo chown -R circleci:circleci $HOME $GITHUB_WORKSPACE'
+      - name: Install latest Clojure
+        working-directory: tool
+        run: bin/install-clojure
+      - name: Install libraries
+        working-directory: tool
+        run: bin/download-test-deps
+      - name: Run tests
+        working-directory: tool
+        run: bin/tests-with-coverage
+
+  lint:
+    runs-on: ubuntu-latest
+    container: circleci/clojure:openjdk-11-tools-deps
+    steps:
+      - uses: actions/checkout@v1
+      - name: Permissions workaround
+        run: 'sudo chown -R circleci:circleci $HOME $GITHUB_WORKSPACE'
+      - working-directory: tool
+        run: clojure -A:lint
+
+  # Kibit is is a static code analyzer for Clojure. It searches for patterns of code that could be
+  # rewritten with a more idiomatic style. https://github.com/jonase/kibit
+  kibit:
+    runs-on: ubuntu-latest
+    container: circleci/clojure:openjdk-11-tools-deps
+    steps:
+      - uses: actions/checkout@v1
+      - name: Permissions workaround
+        run: 'sudo chown -R circleci:circleci $HOME $GITHUB_WORKSPACE'
+      - working-directory: tool
+        run: clojure -A:kibit

--- a/.github/workflows/docs-push.yaml
+++ b/.github/workflows/docs-push.yaml
@@ -1,0 +1,30 @@
+name: Docs Push
+
+on:
+  push:
+    branches:
+      - '*' # prevents workflow from being triggered by pushing/creating tags
+    paths:
+      - 'docs/**'
+      - 'proposals/**'
+      - '**.md'
+      - '.github/workflows/docs-push.yaml'
+
+jobs:
+  lint-prose:
+    runs-on: ubuntu-latest
+    container: jdkato/vale
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run Vale
+      run: |
+        # in this image vale is in the root of the fs and for some reason is not in the PATH
+        export PATH="/:$PATH"
+        bin/lint-prose
+
+  lint-markdown:
+    runs-on: ubuntu-latest
+    container: pipelinecomponents/markdownlint
+    steps:
+    - uses: actions/checkout@v1
+    - run: bin/lint-markdown

--- a/tool/deps.edn
+++ b/tool/deps.edn
@@ -43,7 +43,7 @@
  :aliases {:dev           {:extra-deps  {org.clojure/tools.trace    {:mvn/version "0.7.9"}
                                          inspectable                {:mvn/version "0.2.2"}}
                            :jvm-opts    ["-XX:-OmitStackTraceInFastThrow"
-                                         "--illegal-access=warn"]}
+                                         "--illegal-access=deny"]}
 
            :repl          {:jvm-opts    ["-Dclojure.server.repl={:port,5555,:accept,clojure.core.server/repl}"]}
 
@@ -62,7 +62,10 @@
                            :jvm-opts    ["-Dfile.encoding=UTF8"
                                          ; Prevent the Java app icon from popping up and grabbing
                                          ; focus on MacOS.
-                                         "-Dapple.awt.UIElement=true"]}
+                                         "-Dapple.awt.UIElement=true"
+                                         "-XX:-OmitStackTraceInFastThrow"
+                                         "--illegal-access=deny"
+                                         "-Djava.awt.headless=true"]}
 
            :test/run      {:main-opts   ["-m" "fc4.test-runner.runner"]}
 

--- a/tool/dist/fc4
+++ b/tool/dist/fc4
@@ -21,4 +21,8 @@ JVM_OPTS+=("-Dfile.encoding=UTF8")
 # Prevent the Java app icon from popping up and grabbing focus on MacOS.
 JVM_OPTS+=("-Dapple.awt.UIElement=true")
 
+# Prevent Clojure from performing reflective access across modules, and therefore prevent the JVM
+# from outputting warnings, as per https://clojure.org/guides/faq#illegal_access
+JVM_OPTS+=("--illegal-access=deny")
+
 java "${JVM_OPTS[@]}" -jar "$SCRIPT_DIR/fc4.jar" "$@"


### PR DESCRIPTION
I’m intrigued by the potential of GitHub Actions and want to take some
baby steps into using it.

For now these workflows are mostly redundant with our CircleCI workflow,
but they already have some advantages:

* Actions makes it easy to run one workflow for changes to only a
  specific set of files, and a different workflow for changes to a
  different set of files. That means that we can run the docs jobs when
  the docs change and the code jobs when the code changes — whereas
  CircleCI has no built-in support for this sort of thing.

* The syntax for doing “matrix builds” is so much simpler in Actions
  than in CircleCI; I’ve been meaning to enable matrix builds in
  CircleCI for ages but got stuck in migrating from the 2.0 syntax to
  the 2.1; I’m not absolutely sure but this *seems* much simpler in
  Actions, so simple that this workflow runs the tests on two different
  JDK versions, and it’s pretty clear how to expand the matrix to more
  versions later.
  * The only reason I’ve limited this to two versions for now is because
    we’re currently using CircleCI’s `openjdk` images for running the
    tests, and those appear to be limited to JDK 9 and JDK 11. We can
    switch to different images later (or perhaps run the tests directly
    on the test VM) in order to have easy access to more JDK versions.
  * I’ve already got a MacOS test job set up in a follow-up branch that
    uses a matrix to run on two different versions of MacOS, and that
    job is *almost* working already.