### PR TITLE
Make shell script shebangs consistent

### DIFF
--- a/.circleci/bin/install-lint-deps
+++ b/.circleci/bin/install-lint-deps
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is for installing system dependencies needed to lint the tool.
 

--- a/.circleci/bin/require-java
+++ b/.circleci/bin/require-java
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if ! command -v java >> /dev/null; then
   echo "ERROR in $0: java is expected to be installed!"

--- a/.circleci/bin/which-os
+++ b/.circleci/bin/which-os
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if command -v pacman >> /dev/null; then
   echo 'linux-arch'

--- a/tool/dist/fc4
+++ b/tool/dist/fc4
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # set -x
 


### PR DESCRIPTION
Make shell script shebangs consistent

Use `/usr/bin/env` consistently, everywhere.

As per a discussion with @mattsoutherden on commit 9ec9f05f3d6454b565:

He saw that I changed the shebang of a few scripts from
`#!/usr/bin/env bash` to ``#!/bin/bash` and asked:

> Why this change?
>
> I see you're also doing this in `.circleci/bin/require-java `, but not
> elsewhere. Are you specifically targeting the original OS Bash, or
> trying to avoid a different version?

I replied:

> Thanks for asking about this — I kinda had a feeling in my gut that
> this change was ill-considered and half-assed.
>
> As to why, well, I was frustrated by #245 wherein I accidentally broke
> support for Bash 3, which is the default shell on MacOS 10.13 and
> 10.14 (10.15 switched to zsh as the default shell, but it still ships
> with Bash, still 3.2 due to [licensing concerns][verge-catalina-shells]).
>
> I’m still running MacOS 10.14, but I installed Bash 4.x via Homebrew
> and made that my default shell years ago.
>
> So, on my system, `/usr/bin/env bash` resolves to the 4.x version of
> Bash that I’ve installed via Homebrew, while `/usr/bin/bash` resolves
> to the “system” Bash, which is still 3.x.
>
> My thought process was something like “If the fc4 script used the
> system bash then I would have caught this problem sooner, on my local
> system.”
>
> That’s why I started haphazardly switching a few of the shebangs in
> the shell scripts I was looking at to use the “system” Bash rather
> than using `/usr/bin/env` to use the user’s preferred Bash.
>
> Now that you’ve forced me to think this through, this is clearly a bad
> idea. In general, if I’m going to distribute a shell script, I really
> have no control over what version of Bash a user has installed and set
> up. Any shell script I distribute should probably _always_ use
> `/usr/bin/env` to find the user’s preferred _whatever_ — Bash, Python,
> etc.
>
> OTOH, there are two classes of shell scripts included in this project:
> those that are distributed to end-users and therefore must be highly
> portable — there’s only one of these, the `fc4` script — and those
> that run in our CI environment, which we (more or less) control and
> which is drastically more deterministic than the other class.
>
> Wow, this is quite a missive at this point… I’ll just cut it off here.
> Sorry. I think I’ll just change all the scripts to be consistent
> (within the two classes). Let me know if you agree/disagree. Thanks!

[verge-catalina-shells]: https://www.theverge.com/2019/6/4/18651872/apple-macos-catalina-zsh-bash-shell-replacement-features

Matt:

> Even with the `/bin/bash` entries, people can still force update their
> system bash, or it might be a new version in a new OS release. So it's
> not just `env` that may link to a newer version that you might expect.
>
> Given that, I don't think there's any reason not to use `env`, as that
> will still do what you expect in the controlled CI environments, and
> as you say, we should use the user's choice in the distribution
> scripts anyway.

Me:

> Agreed. I’ll fix this soon. Thanks!

Thanks again Matt!