### PR TITLE
Update tests to handle changes to Structurizr Express

### DIFF
--- a/tool/test/data/structurizr/express/diagram_valid_expected.svg
+++ b/tool/test/data/structurizr/express/diagram_valid_expected.svg
@@ -2,91 +2,91 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 1748 1740">
   <g>
     <g xmlns:xlink="http://www.w3.org/1999/xlink" id="v-3" class="joint-viewport" transform="matrix(1,0,0,1,0,0)">
-      <g id="j_12" model-id="d12c5ebd-c853-48a1-8e49-d0b06692d618" class="joint-theme-default joint-cell joint-type-structurizr joint-type-structurizr-diagrammetadata joint-element" data-type="structurizr.diagramMetadata" transform="translate(20,1224)">
-        <g id="v-93">
-          <text class="structurizrDiagramMetadata structurizrMetadata" id="v-94" font-weight="normal" font-size="22px" text-anchor="start" fill="#777777" pointer-events="none" font-family="Open Sans"/>
+      <g id="j_12" model-id="16c12989-7fd2-44de-9a18-c8de6a52f73b" class="joint-theme-default joint-cell joint-type-structurizr joint-type-structurizr-diagrammetadata joint-element" data-type="structurizr.diagramMetadata" transform="translate(20,1224)">
+        <g id="v-91">
+          <text class="structurizrDiagramMetadata structurizrMetadata" id="v-92" font-weight="normal" font-size="22px" text-anchor="start" fill="#777777" pointer-events="none" font-family="Open Sans"/>
         </g>
       </g>
-      <g id="j_11" model-id="37e6021e-59e7-414e-bb2c-8188d208ae47" class="joint-theme-default joint-cell joint-type-structurizr joint-type-structurizr-diagramdescription joint-element" data-type="structurizr.diagramDescription" transform="translate(20,1195)">
-        <g id="v-89">
-          <text y="0.8em" text-anchor="start" transform="matrix(1,0,0,1,0,0)" font-size="22px" font-weight="normal" fill="#777777" id="v-90" class="structurizrDiagramDescription structurizrMetadata" pointer-events="none" font-family="Open Sans">
-            <tspan id="v-91" class="v-line" dy="0em" x="0">Big-picture diagram showing how our top-level systems and stakeholders interact | Structurizr is available as a cloud service and on-premises installation - structurizr.com</tspan>
-          </text>
-        </g>
-      </g>
-      <g id="j_10" model-id="17c1cc94-58e9-4016-9d70-d855e756f4cd" class="joint-theme-default joint-cell joint-type-structurizr joint-type-structurizr-diagramtitle joint-element" data-type="structurizr.diagramTitle" transform="translate(20,1149)">
-        <g id="v-85">
-          <text y="0.8em" text-anchor="start" transform="matrix(1,0,0,1,0,0)" font-size="36px" font-weight="bold" fill="#000000" id="v-86" class="structurizrDiagramTitle structurizrMetadata" pointer-events="none" font-family="Open Sans">
-            <tspan id="v-87" class="v-line" dy="0em" x="0">System Landscape diagram for Acme inc.</tspan>
+      <g id="j_11" model-id="731abb5a-4daf-49a1-b168-59def8f108f5" class="joint-theme-default joint-cell joint-type-structurizr joint-type-structurizr-diagramdescription joint-element" data-type="structurizr.diagramDescription" transform="translate(20,1195)">
+        <g id="v-87">
+          <text y="0.8em" text-anchor="start" transform="matrix(1,0,0,1,0,0)" font-size="22px" font-weight="normal" fill="#777777" id="v-88" class="structurizrDiagramDescription structurizrMetadata" pointer-events="none" font-family="Open Sans">
+            <tspan id="v-89" class="v-line" dy="0em" x="0">Big-picture diagram showing how our top-level systems and stakeholders interact</tspan>
           </text>
         </g>
       </g>
-      <g id="j_6" model-id="21dbe17c-cd2f-4447-89f6-04499e0bff87" class="joint-theme-default joint-cell joint-type-structurizr joint-type-structurizr-person joint-element" data-type="structurizr.person" transform="translate(125,50)" style="cursor: move !important">
-        <g class="structurizrElement" id="v-35">
-          <rect y="160" rx="70" stroke="#c7c7c7" fill="#dddddd" width="400" stroke-width="2" id="v-37" class="structurizrPersonBody structurizrHighlightableElement" x="0" pointer-events="visiblePainted" height="240"/>
-          <circle r="88.88888888888889" stroke="#c7c7c7" fill="#dddddd" stroke-width="2" cx="200" id="v-36" class="structurizrPersonHead structurizrHighlightableElement" cy="88.88888888888889" pointer-events="visiblePainted"/>
-          <line class="structurizrPersonRightArm" x1="80" y1="266.6666666666667" x2="80" y2="400" style="stroke-width:2px" id="v-43" stroke="#c7c7c7"/>
-          <line class="structurizrPersonLeftArm" x1="320" y1="266.6666666666667" x2="320" y2="400" style="stroke-width:2px" id="v-44" stroke="#c7c7c7"/>
-          <text y="0.8em" text-anchor="middle" transform="matrix(1,0,0,1,200,235)" font-size="34px" font-weight="bold" fill="#000000" id="v-38" class="structurizrName" pointer-events="visible" font-family="Open Sans">
-            <tspan id="v-45" class="v-line" dy="0em" x="0">A</tspan>
+      <g id="j_10" model-id="c3e2a27d-fb1a-4140-b4b5-51a0a0887d23" class="joint-theme-default joint-cell joint-type-structurizr joint-type-structurizr-diagramtitle joint-element" data-type="structurizr.diagramTitle" transform="translate(20,1149)">
+        <g id="v-83">
+          <text y="0.8em" text-anchor="start" transform="matrix(1,0,0,1,0,0)" font-size="36px" font-weight="bold" fill="#000000" id="v-84" class="structurizrDiagramTitle structurizrMetadata" pointer-events="none" font-family="Open Sans">
+            <tspan id="v-85" class="v-line" dy="0em" x="0">System Landscape diagram for Acme inc.</tspan>
           </text>
-          <text class="structurizrMetaData" id="v-39" font-size="19px" y="0.8em" text-anchor="middle" font-family="Open Sans" fill="#000000" transform="matrix(1,0,0,1,200,275)">
-            <tspan id="v-46" class="v-line" dy="0em" x="0">[Person]</tspan>
-          </text>
-          <text y="0.8em" text-anchor="middle" transform="matrix(1,0,0,1,200,325)" font-size="24px" fill="#000000" id="v-40" class="structurizrDescription" display="none" font-family="Open Sans">
-            <tspan id="v-47" class="v-line v-empty-line" dy="0em" x="0" style="fill-opacity: 0; stroke-opacity: 0;">-</tspan>
-          </text>
-          <text text-anchor="middle" transform="matrix(1,0,0,1,200,371.2)" font-size="24" font-weight="bold" fill="#a6a6a6" id="v-41" class="structurizrNavigation" display="none" font-family="Open Sans"/>
-          <image class="structurizrIcon" id="v-42"/>
         </g>
       </g>
-      <g id="j_7" model-id="9e24e550-2160-492a-baa0-1c09461ed2bc" class="joint-theme-default joint-cell joint-type-structurizr joint-type-structurizr-box joint-element" data-type="structurizr.box" transform="translate(800,100)" style="cursor: move !important">
-        <g class="structurizrElement" id="v-49">
-          <rect rx="1" stroke="#c7c7c7" fill="#dddddd" width="450" stroke-width="2" id="v-50" class="structurizrBox structurizrHighlightableElement" pointer-events="visiblePainted" ry="1" height="300"/>
-          <text y="0.8em" text-anchor="middle" transform="matrix(1,0,0,1,225,105)" font-size="34" font-weight="bold" fill="#000000" id="v-51" class="structurizrName" pointer-events="visible" font-family="Open Sans">
-            <tspan id="v-56" class="v-line" dy="0em" x="0">B</tspan>
+      <g id="j_6" model-id="569f0793-d96c-4785-83cb-1bef29fdc922" class="joint-theme-default joint-cell joint-type-structurizr joint-type-structurizr-person joint-element" data-type="structurizr.person" transform="translate(105,30)" style="cursor: move !important">
+        <g class="structurizrElement" id="v-34" style="opacity: 1;">
+          <rect y="160" rx="70" stroke="#c7c7c7" fill="#dddddd" width="400" stroke-width="2" id="v-36" class="structurizrPersonBody structurizrHighlightableElement" x="0" pointer-events="visiblePainted" height="240"/>
+          <circle r="88.88888888888889" stroke="#c7c7c7" fill="#dddddd" stroke-width="2" cx="200" id="v-35" class="structurizrPersonHead structurizrHighlightableElement" cy="88.88888888888889" pointer-events="visiblePainted"/>
+          <line class="structurizrPersonRightArm" x1="80" y1="266.6666666666667" x2="80" y2="400" style="stroke-width:2px" id="v-42" stroke="#c7c7c7"/>
+          <line class="structurizrPersonLeftArm" x1="320" y1="266.6666666666667" x2="320" y2="400" style="stroke-width:2px" id="v-43" stroke="#c7c7c7"/>
+          <text y="0.8em" text-anchor="middle" transform="matrix(1,0,0,1,200,235)" font-size="34px" font-weight="bold" fill="#000000" id="v-37" class="structurizrName" pointer-events="visible" font-family="Open Sans">
+            <tspan id="v-44" class="v-line" dy="0em" x="0">A</tspan>
           </text>
-          <text class="structurizrMetaData" id="v-52" font-size="19" y="0.8em" text-anchor="middle" font-family="Open Sans" fill="#000000" transform="matrix(1,0,0,1,225,145)">
-            <tspan id="v-57" class="v-line" dy="0em" x="0">[Software System]</tspan>
+          <text class="structurizrMetaData" id="v-38" font-size="19px" y="0.8em" text-anchor="middle" font-family="Open Sans" fill="#000000" transform="matrix(1,0,0,1,200,275)">
+            <tspan id="v-45" class="v-line" dy="0em" x="0">[Person]</tspan>
           </text>
-          <text y="0.8em" text-anchor="middle" transform="matrix(1,0,0,1,225,195)" font-size="24" fill="#000000" id="v-53" class="structurizrDescription" display="none" font-family="Open Sans">
-            <tspan id="v-58" class="v-line v-empty-line" dy="0em" x="0" style="fill-opacity: 0; stroke-opacity: 0;">-</tspan>
+          <text y="0.8em" text-anchor="middle" transform="matrix(1,0,0,1,200,325)" font-size="24px" fill="#000000" id="v-39" class="structurizrDescription" display="none" font-family="Open Sans">
+            <tspan id="v-46" class="v-line v-empty-line" dy="0em" x="0" style="fill-opacity: 0; stroke-opacity: 0;">-</tspan>
           </text>
-          <text text-anchor="middle" transform="matrix(1,0,0,1,225,270)" font-size="24" font-weight="bold" fill="#a6a6a6" id="v-54" class="structurizrNavigation" display="none" font-family="Open Sans"/>
-          <image class="structurizrIcon" id="v-55"/>
+          <text text-anchor="middle" transform="matrix(1,0,0,1,200,371.2)" font-size="24" font-weight="bold" fill="#a6a6a6" id="v-40" class="structurizrNavigation" display="none" font-family="Open Sans"/>
+          <image class="structurizrIcon" id="v-41"/>
         </g>
       </g>
-      <g id="j_8" model-id="373e19d0-95a0-4a79-94ea-292b39051cca" class="joint-theme-default joint-cell joint-type-structurizr joint-type-structurizr-relationship joint-link" data-type="structurizr.relationship">
-        <path class="connection" stroke="#707070" id="v-74" stroke-width="2" stroke-dasharray="30 30" fill="none" d="M 525 250 780 250"/>
-        <path class="marker-source" fill="black" stroke="black" transform="translate(525,250) scale(1,1) rotate(0)"/>
-        <path class="marker-target" fill="#707070" stroke="#707070" id="v-76" d="M 20 0 L 0 10 L 20 20 z" transform="translate(800,260) scale(1,1) rotate(-180)"/>
-        <path class="connection-wrap" id="v-75" fill="none" d="M 525 250 780 250"/>
+      <g id="j_7" model-id="d7b1dd86-700f-49a1-a5e8-6e1637aae8b7" class="joint-theme-default joint-cell joint-type-structurizr joint-type-structurizr-box joint-element" data-type="structurizr.box" transform="translate(843,98)" style="cursor: move !important">
+        <g class="structurizrElement" id="v-48" style="opacity: 1;">
+          <rect rx="1" stroke="#c7c7c7" fill="#dddddd" width="450" stroke-width="2" id="v-49" class="structurizrBox structurizrHighlightableElement" pointer-events="visiblePainted" ry="1" height="300"/>
+          <text y="0.8em" text-anchor="middle" transform="matrix(1,0,0,1,225,105)" font-size="34" font-weight="bold" fill="#000000" id="v-50" class="structurizrName" pointer-events="visible" font-family="Open Sans">
+            <tspan id="v-55" class="v-line" dy="0em" x="0">B</tspan>
+          </text>
+          <text class="structurizrMetaData" id="v-51" font-size="19" y="0.8em" text-anchor="middle" font-family="Open Sans" fill="#000000" transform="matrix(1,0,0,1,225,145)">
+            <tspan id="v-56" class="v-line" dy="0em" x="0">[Software System]</tspan>
+          </text>
+          <text y="0.8em" text-anchor="middle" transform="matrix(1,0,0,1,225,195)" font-size="24" fill="#000000" id="v-52" class="structurizrDescription" display="none" font-family="Open Sans">
+            <tspan id="v-57" class="v-line v-empty-line" dy="0em" x="0" style="fill-opacity: 0; stroke-opacity: 0;">-</tspan>
+          </text>
+          <text text-anchor="middle" transform="matrix(1,0,0,1,225,270)" font-size="24" font-weight="bold" fill="#a6a6a6" id="v-53" class="structurizrNavigation" display="none" font-family="Open Sans"/>
+          <image class="structurizrIcon" id="v-54"/>
+        </g>
+      </g>
+      <g id="j_8" model-id="e3962a40-a061-44ea-8ae3-6d357090013d" class="joint-theme-default joint-cell joint-type-structurizr joint-type-structurizr-relationship joint-link" data-type="structurizr.relationship">
+        <path class="connection" stroke="#707070" id="v-73" stroke-width="2" stroke-dasharray="30 30" fill="none" d="M 505 235 823 243" style="opacity: 1;"/>
+        <path class="marker-source" fill="black" stroke="black" transform="translate(505,235) scale(1,1) rotate(1.355865478515625)"/>
+        <path class="marker-target" fill="#707070" stroke="#707070" id="v-75" d="M 20 0 L 0 10 L 20 20 z" transform="translate(842.7633866663309,252.99720317128987) scale(1,1) rotate(-178.64413452148438)" style="opacity: 1;"/>
+        <path class="connection-wrap highlightedLink" id="v-74" fill="none" d="M 505 235 823 243"/>
         <title class="tooltip"/>
         <g class="labels">
-          <g class="label" id="v-66" label-idx="0" transform="translate(652.5, 250)">
-            <rect rx="3" stroke="#ffffff" transform="matrix(1,0,0,1,-84,-16.8)" fill="#ffffff" width="167.9375" stroke-width="20px" id="v-68" pointer-events="none" ry="3" height="33.78125"/>
-            <text y="0.8em" text-anchor="middle" transform="matrix(1,0,0,1,0,-9.5)" font-size="24px" font-weight="bold" fill="#707070" id="v-67" pointer-events="none" font-family="Open Sans">
-              <tspan id="v-69" class="v-line" dy="0em" x="0">interacts with</tspan>
+          <g class="label" id="v-65" label-idx="0" transform="translate(664, 239)" style="opacity: 1;">
+            <rect rx="3" stroke="#ffffff" transform="matrix(1,0,0,1,-84,-16.8)" fill="#ffffff" width="167.9375" stroke-width="20px" id="v-67" pointer-events="none" ry="3" height="33.78125"/>
+            <text y="0.8em" text-anchor="middle" transform="matrix(1,0,0,1,0,-9.5)" font-size="24px" font-weight="bold" fill="#707070" id="v-66" pointer-events="none" font-family="Open Sans">
+              <tspan id="v-68" class="v-line" dy="0em" x="0">interacts with</tspan>
             </text>
           </g>
-          <g class="label" id="v-70" label-idx="1" transform="translate(652.5, 281.2)">
-            <rect id="v-72" fill="#ffffff" rx="3" ry="3" pointer-events="none" width="0" height="0" transform="matrix(1,0,0,1,0,0)"/>
-            <text y="0.8em" text-anchor="middle" transform="matrix(1,0,0,1,0,0)" font-size="19px" font-weight="normal" fill="#707070" id="v-71" display="none" pointer-events="none" font-family="Open Sans">
-              <tspan id="v-73" class="v-line v-empty-line" dy="0em" x="0" style="fill-opacity: 0; stroke-opacity: 0;">-</tspan>
+          <g class="label" id="v-69" label-idx="1" transform="translate(664, 270.2)" style="opacity: 1;">
+            <rect id="v-71" fill="#ffffff" rx="3" ry="3" pointer-events="none" width="0" height="0" transform="matrix(1,0,0,1,0,0)"/>
+            <text y="0.8em" text-anchor="middle" transform="matrix(1,0,0,1,0,0)" font-size="19px" font-weight="normal" fill="#707070" id="v-70" display="none" pointer-events="none" font-family="Open Sans">
+              <tspan id="v-72" class="v-line v-empty-line" dy="0em" x="0" style="fill-opacity: 0; stroke-opacity: 0;">-</tspan>
             </text>
           </g>
         </g>
         <g class="marker-vertices" display="none"/>
-        <g class="marker-arrowheads" id="v-78" display="none">
-          <g class="marker-arrowhead-group marker-arrowhead-group-source" id="v-63">
+        <g class="marker-arrowheads" id="v-77" display="none">
+          <g class="marker-arrowhead-group marker-arrowhead-group-source" id="v-62">
             <path class="marker-arrowhead" end="source" d="M 26 0 L 0 13 L 26 26 z"/>
           </g>
-          <g class="marker-arrowhead-group marker-arrowhead-group-target" id="v-64">
+          <g class="marker-arrowhead-group marker-arrowhead-group-target" id="v-63">
             <path class="marker-arrowhead" end="target" d="M 26 0 L 0 13 L 26 26 z"/>
           </g>
         </g>
-        <g class="link-tools" id="v-77" display="none">
-          <g class="link-tool" id="v-62" transform="translate(565, 250) ">
+        <g class="link-tools" id="v-76" display="none">
+          <g class="link-tool" id="v-61" transform="translate(544.9873657226562, 236.00596618652344) ">
             <g class="tool-remove" event="remove">
               <circle r="11"/>
               <path transform="scale(.8) translate(-16, -16)" d="M24.778,21.419 19.276,15.917 24.777,10.415 21.949,7.585 16.447,13.087 10.945,7.585 8.117,10.415 13.618,15.917 8.116,21.419 10.946,24.248 16.447,18.746 21.948,24.248z"/>
@@ -100,10 +100,10 @@
           </g>
         </g>
       </g>
-      <g id="j_9" model-id="aad6475c-8fce-417c-9d29-16392804ba83" class="joint-theme-default joint-cell joint-type-structurizr joint-type-structurizr-diagramwatermark joint-element" data-type="structurizr.diagramWatermark" transform="translate(873.5,188)">
-        <g id="v-80">
-          <text y="0.8em" text-anchor="middle" stroke="#777777" transform="matrix(1,0,0,1,0,0)" font-size="291.3333333333333px" font-weight="bolder" fill="#999999" stroke-width="2px" opacity="0.02" id="v-81" class="structurizrDiagramWatermark" pointer-events="none" font-family="Open Sans">
-            <tspan id="v-83" class="v-line" dy="0em" x="0">Structurizr</tspan>
+      <g id="j_9" model-id="140f79c4-8fbb-45ca-8825-c63942eac1a3" class="joint-theme-default joint-cell joint-type-structurizr joint-type-structurizr-diagramwatermark joint-element" data-type="structurizr.diagramWatermark" transform="translate(1478,1135)">
+        <g id="v-79">
+          <text y="0.8em" text-anchor="middle" stroke="#cccccc" transform="matrix(1,0,0,1,0,0)" font-size="100px" font-weight="normal" fill="#cccccc" stroke-width="2px" opacity="1" id="v-80" class="structurizrDiagramWatermark" pointer-events="none" font-family="Open Sans">
+            <tspan id="v-81" class="v-line" dy="0em" x="0">Structurizr</tspan>
           </text>
         </g>
       </g>

--- a/tool/test/fc4/io/cli/main_test.clj
+++ b/tool/test/fc4/io/cli/main_test.clj
@@ -113,7 +113,7 @@
                  "\nOpts, parsed:\n" (parse-opts opts main/options-spec)))))))
 
 (def max-allowable-image-differences
-  {:svg 0.05
+  {:svg 0.06
    ;; The PNG threshold might seem low, but the diffing algorithm is
    ;; giving very low results for some reason. This threshold seems
    ;; to be sufficient to make the random watermark effectively ignored

--- a/tool/test/fc4/io/render_test.clj
+++ b/tool/test/fc4/io/render_test.clj
@@ -26,7 +26,7 @@
     (check `r/check-render-result)))
 
 (def max-allowable-image-differences
-  {:svg 0.05
+  {:svg 0.06
    ;; The PNG threshold might seem low, but the diffing algorithm is
    ;; giving very low results for some reason. This threshold seems
    ;; to be sufficient to make the random watermark effectively ignored


### PR DESCRIPTION
I was working on something unrelated and the rendering tests started
failing with output like this:

```
expected: (<= distance-percentage (:svg max-allowable-image-differences))
  actual: (not (<= 0.052500776638707676 0.05))
```

as you can see, the rendered SVG image was 5.25% different than the
expected image, which exceeded the max allowable difference of 5%.

I took a look and it seems that Simon Brown has made some minor changes
to Structurizr Express’ rendering; mostly to the watermark that
Structurizr Express has been adding to rendered images. Well, actually
he seems to have removed the watermark and replaced it with a larger,
more opaque Structurizr wordmark in a fixed location.

This is of course 100% fine; it’s his product and it’s his prerogative
to change it however he sees fit, at any time. I have zero problems with
him making this change unannounced; when I chose to have FC4 “wrap” SE
and invoke its rendering routines programmatically, I knew that there
were zero guarantees that SE would continue to function, or to be
available, and I knew that it would be my responsibility to update FC4
if and when SE changed or was retired.

So! There are two changes here:

1. Update the “expected” image to one rendered with the new wordmark
2. Increase the maximum allowable image difference to 6%

I made the latter change because the differences in the rendering here
were so visually trivial, to my eye, that it wasn’t necessary for the
tests to fail in this case.

## Notes to Reviewers

1. I think you can skip over the diff of the SVG file — it’s mostly just noise. Random IDs, that sort of thing.