### PR TITLE
Fix flaky test on MacOS in CircleCI

### DIFF
--- a/test/fc4/util_test.clj
+++ b/test/fc4/util_test.clj
@@ -58,8 +58,8 @@
 (deftest with-timeout
   (testing "a body that finishes executing before the timeout has elapsed"
     (is (true? (u/with-timeout 100
-                 (do (Thread/sleep 50) true)))))
+                 (do (Thread/sleep 10) true)))))
   (testing "a body that takes longer than the timeout to finish"
     (is (thrown? TimeoutException
                  (u/with-timeout 100
-                   (do (Thread/sleep 150) true))))))
+                   (do (Thread/sleep 200) true))))))


### PR DESCRIPTION
This test was intermittently failing with output like this:

```
a body that takes longer than the timeout to finish
  expected: (thrown? TimeoutException
                     (u/with-timeout 100 (do (Thread/sleep 150) true)))
  actual: nil
```

And sometimes the inverse.

I assume this has something to do with the virtualization setup, or the fact that the MacOS executors on CircleCI are seemingly slow in general.