### PR TITLE
Website: fix links and redirects

### DIFF
--- a/docs/docs/manual/authoring-workflow.md
+++ b/docs/docs/manual/authoring-workflow.md
@@ -1,8 +1,7 @@
 ---
 # Cool URLs don’t change: https://www.w3.org/Provider/Style/URI.html
 redirect_from:
-  - /methodology/authoring_workflow
-  - /methodology/authoring_workflow.html
+  - ../../methodology/authoring_workflow.html
 ---
 # 7. The Authoring Workflow « FC4 User Manual
 
@@ -83,9 +82,9 @@ Here’s a screenshot of Structurizr Express:
 
 ----
 
-Please continue to [Publishing](/docs/manual/publishing) or go back to [the top page of the manual](/docs/manual).
+Please continue to [Publishing](./publishing) or go back to [the top page of the manual](./).
 
-[formatting]: /docs/features#formatting
-[snapping]: /docs/features#snapping
-[rendering]: /docs/features#rendering
-[repo]: /docs/manual/repository
+[formatting]: ../features#formatting
+[snapping]: ../features#snapping
+[rendering]: ../features#rendering
+[repo]: ./repository

--- a/docs/docs/manual/graphical-notation.md
+++ b/docs/docs/manual/graphical-notation.md
@@ -1,8 +1,7 @@
 ---
 # Cool URLs don’t change: https://www.w3.org/Provider/Style/URI.html
 redirect_from:
-  - /methodology/graphical_notation
-  - /methodology/graphical_notation.html
+  - ../../methodology/graphical_notation.html
 ---
 # 3. The Graphical Notation « FC4 User Manual
 
@@ -32,7 +31,7 @@ This example is by [Simon Brown][simon-brown]:
 Please continue to [The Toolset][toolset] or go back to [the top page of the manual][manual].
 
 
-[manual]: /docs/manual
+[manual]: ./
 [simon-brown]: http://simonbrown.je/
 [structurizr-express]: https://structurizr.com/express
-[toolset]: /docs/manual/toolset
+[toolset]: ./toolset

--- a/docs/docs/manual/index.md
+++ b/docs/docs/manual/index.md
@@ -1,9 +1,7 @@
 ---
 # Cool URLs don’t change: https://www.w3.org/Provider/Style/URI.html
 redirect_from:
-  - /methodology
-  - /methodology/
-  - /methodology.html
+  - ../../methodology/index.html
 ---
 # User Manual
 

--- a/docs/docs/manual/installation.md
+++ b/docs/docs/manual/installation.md
@@ -52,7 +52,7 @@ install the tool:
 
 ----
 
-Please continue to [The Repository](/docs/manual/repository) or go back to [the top page of the manual](/docs/manual).
+Please continue to [The Repository](./repository) or go back to [the top page of the manual](./).
 
 
 [adoptopenjdk]: https://adoptopenjdk.net/installation.html?variant=openjdk11&jvmVariant=hotspot

--- a/docs/docs/manual/publishing.md
+++ b/docs/docs/manual/publishing.md
@@ -1,8 +1,7 @@
 ---
 # Cool URLs don’t change: https://www.w3.org/Provider/Style/URI.html
 redirect_from:
-  - /methodology/publishing
-  - /methodology/publishing.html
+  - ../../methodology/publishing.html
 ---
 # 8. Publishing « FC4 User Manual
 
@@ -11,9 +10,9 @@ will probably tend to be specific to the organization employing FC4.
 
 However, we could probably collect some suggestions here:
 
-Coming soon → please [contribute](/contributing)!
+Coming soon → please [contribute](../../contributing)!
 
 ----
 
 This is the last page of the manual. Thanks for reading! You may wish to return to
-[the top page of the manual](/docs/manual).
+[the top page of the manual](./).

--- a/docs/docs/manual/repository.md
+++ b/docs/docs/manual/repository.md
@@ -1,8 +1,7 @@
 ---
 # Cool URLs don’t change: https://www.w3.org/Provider/Style/URI.html
 redirect_from:
-  - /methodology/repository
-  - /methodology/repository.html
+  - ../../methodology/repository.html
 ---
 # 6. The Repository « FC4 User Manual
 
@@ -201,10 +200,10 @@ diagrams
 
 ----
 
-Please continue to [The Authoring Workflow](/docs/manual/authoring-workflow) or go back to
-[the top page of the manual](/docs/manual).
+Please continue to [The Authoring Workflow](./authoring-workflow) or go back to
+[the top page of the manual](./).
 
 
 [git-lfs]: https://git-lfs.github.com/
 [github-image-diffing]: https://help.github.com/articles/rendering-and-diffing-images/#viewing-differences
-[scheme]: /docs/manual/scheme
+[scheme]: ./scheme

--- a/docs/docs/manual/scheme.md
+++ b/docs/docs/manual/scheme.md
@@ -1,8 +1,7 @@
 ---
 # Cool URLs don’t change: https://www.w3.org/Provider/Style/URI.html
 redirect_from:
-  - /methodology/scheme
-  - /methodology/scheme.html
+  - ../../methodology/scheme.html
 ---
 # 1. The Scheme « FC4 User Manual
 
@@ -49,5 +48,5 @@ Anyone using FC4 is of course free to use or not use whichever diagrams they see
 
 ----
 
-Please continue to [The Textual Notation](/docs/manual/textual-notation) or go back to
-[the top page of the manual](/docs/manual).
+Please continue to [The Textual Notation](./textual-notation) or go back to
+[the top page of the manual](./).

--- a/docs/docs/manual/textual-notation.md
+++ b/docs/docs/manual/textual-notation.md
@@ -1,8 +1,7 @@
 ---
 # Cool URLs don’t change: https://www.w3.org/Provider/Style/URI.html
 redirect_from:
-  - /methodology/textual_notation
-  - /methodology/textual_notation.html
+  - ../../methodology/textual_notation.html
 ---
 # 2. The Textual Notation « FC4 User Manual
 
@@ -16,7 +15,7 @@ We have a few key requirements for our textual notation:
 
 For now we are using a [YAML](http://yaml.org) format that meets these requirements. It comes from,
 and is supported by, [Structurizr Express](https://structurizr.com/help/express), a tool described
-in [The Toolset](/docs/manual/toolset).
+in [The Toolset](./toolset).
 
 The format supports describing:
 
@@ -136,5 +135,5 @@ size: A5_Landscape
 
 ----
 
-Please continue to [The Graphical Notation](/docs/manual/graphical-notation) or go back to
-[the top page of the manual](/docs/manual).
+Please continue to [The Graphical Notation](./graphical-notation) or go back to
+[the top page of the manual](./).

--- a/docs/docs/manual/toolset.md
+++ b/docs/docs/manual/toolset.md
@@ -1,8 +1,7 @@
 ---
 # Cool URLs don’t change: https://www.w3.org/Provider/Style/URI.html
 redirect_from:
-  - /methodology/toolset
-  - /methodology/toolset.html
+  - ../../methodology/toolset.html
 ---
 # 4. The Toolset « FC4 User Manual
 
@@ -58,4 +57,4 @@ The current toolset for authoring and editing FC4 diagrams is:
 
 ----
 
-Please continue to [Installation](/docs/manual/installation) or go back to [the top page of the manual](/docs/manual).
+Please continue to [Installation](./installation) or go back to [the top page of the manual](./).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,6 @@
 ---
 redirect_from:
-  - /tool
-  - /tool.html
+  - tool/index.html
 ---
 # FC4
 
@@ -66,7 +65,7 @@ software architecture diagrams using [the C4 model for visualising software arch
 
 ## Get Started
 
-To get started, please see [Get started with FC4](/docs/get-started).
+To get started, please see [Get started with FC4](docs/get-started).
 
 
 ## Help & Feedback
@@ -77,14 +76,14 @@ will get back to you shortly.
 
 ## Documentation
 
-* [Change History](/change-history)
+* [Change History](change-history)
 * [Command Line Interface (CLI) Reference](docs/reference/cli)
-* [Contributing](/contributing)
-* [Developing and Testing](/docs/dev)
-* [Features](/docs/features)
-* [Installation](/docs/manual/installation)
-* [The Name](/docs/name)
-* [User Manual](/docs/manual)
+* [Contributing](contributing)
+* [Developing and Testing](docs/dev)
+* [Features](docs/features)
+* [Installation](docs/manual/installation)
+* [The Name](docs/name)
+* [User Manual](docs/manual)
 
 
 ## See Also


### PR DESCRIPTION
When I tested the website locally, the absolute links (those starting
with a slash) worked just fine, because in that scenario the site is
“rooted” at the host root — e.g. `docs/manual/scheme.md` is
accessible at `http://localhost:4000/docs/manual/scheme.md` so an
absolute link like `/docs/manual/scheme` works just fine.

When the website is published to GitHub Pages, however, it’s a
[“repo site”][gh-pages-types] — so it’s rooted under a subdirectory,
i.e. there’s an additional segment in the URL, the first one, so
`docs/manual/scheme.md` becomes
`https://fundingcircle.github.io/fc4-framework/docs/manual/scheme.md` so
an absolute link like `/docs/manual/scheme` won’t work — it has to be
relative so that it’ll work in either scenario.

So the links all broke when we merged #257 a few minutes ago.

So I changed all the absolute links to relative.

This also made me realize that the way I’d constructed the redirects
might not work, and even if they did work, they didn’t necessarily
sense. So I changed those to use relative paths as well, which is more
consistent and sensical, and I also removed the redundant redirects, as
[jekyll_redirect_from][jrf] just created HTML files that direct the
browser to redirect to the new URL (using HTML tags, not HTTP status
codes). In other words, there never was a URL like `tool.html` — there
was only `tool/index.html` which was also accessible via `tool` or
`tool/`

[gh-pages-types]: https://git.io/JepJd
[jrf]: https://github.com/jekyll/jekyll-redirect-from