### PR TITLE
More faster CI

### DIFF
--- a/.circleci/bin/halt-if-unchanged
+++ b/.circleci/bin/halt-if-unchanged
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -eu
+
+# This script makes CircleCI halt the current job without failing if the paths passed as an argument
+# haven't changed.
+#
+# Example usage:
+# .circleci/bin/halt-if-unchanged path/to/dir1 path/to/dir2
+#
+# For reference:
+# * https://fant.io/p/circleci-early-exit/
+# * https://gist.github.com/naesheim/18d0c0a58ee61f4674353a2f4cf71475
+# * https://discuss.circleci.com/t/ability-to-return-successfully-from-a-job-before-completing-all-the-next-steps/12969/4
+
+# 1. Get all the arguments of the script
+# https://unix.stackexchange.com/a/197794
+PATHS_TO_SEARCH=("$@")
+
+# 2. Make sure the paths to search are not empty
+if [ -z "${PATHS_TO_SEARCH[*]}" ]; then
+  echo "Please provide the paths to search for."
+  echo "Example usage:"
+  echo ".circleci/bin/halt-if-unchanged path/to/dir1 path/to/dir2"
+  exit 1
+fi
+
+# 3. Get the latest commit
+LATEST_COMMIT=$(git rev-parse HEAD)
+
+# 4. Get the latest commit in the searched paths
+LATEST_COMMIT_IN_PATH=$(git log -1 --format=format:%H --full-diff "${PATHS_TO_SEARCH[@]}")
+
+if [ "$LATEST_COMMIT" != "$LATEST_COMMIT_IN_PATH" ]; then
+  echo "Halting this CircleCI job because files in these paths have not changed:"
+  echo "${PATHS_TO_SEARCH[@]}"
+  circleci step halt
+fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,14 +48,18 @@ commands:
       - run:
           name: Install system dependencies
           command: .circleci/bin/install-sys-deps/$OS-<<parameters.scenario>>
-  install-tar:
-    description: Install tar on Arch Linux so we can restore caches
+  install-arch-stuff:
+    description: |
+      Install stuff needed specifically for Arch Linux very early on: git so we can run
+      `halt-if-unchanged` and tar so we can restore caches. This is specific to Arch because
+      apparently the Arch images are very bare-bones, unlike Debian and Mac images. I suspect if we
+      ever build on Alpine again we might have to do something similar.
     steps:
       - run:
-          name: Install tar
+          name: Install git and tar (if on Arch)
           command: |
             if command -v pacman >> /dev/null; then
-              pacman --refresh --sync --needed --noconfirm --noprogressbar tar
+              pacman --refresh --sync --needed --noconfirm --noprogressbar git tar
             fi
 
 jobs:
@@ -65,8 +69,9 @@ jobs:
          type: string
      executor: << parameters.executor >>
      steps:
+       - install-arch-stuff
        - checkout
-       - install-tar
+       - run: .circleci/bin/halt-if-unchanged .circleci src test deps.edn
        - restore_cache:
            keys:
              - test-deps-v2-{{checksum "deps.edn"}}-{{checksum "bin/download-test-deps"}}-<< parameters.executor >>
@@ -89,6 +94,7 @@ jobs:
      executor: debian-11
      steps:
        - checkout
+       - run: .circleci/bin/halt-if-unchanged .circleci src deps.edn
        - restore_cache: {keys: ['clj-lint-deps-v1-{{checksum "deps.edn"}}']}
        - install-sys-deps:
            scenario: lint
@@ -108,6 +114,7 @@ jobs:
      executor: debian-11
      steps:
        - checkout
+       - run: .circleci/bin/halt-if-unchanged .circleci src deps.edn
        - restore_cache: {keys: ['kibit-deps-v1-{{checksum "deps.edn"}}']}
        - install-sys-deps:
            scenario: lint
@@ -126,6 +133,7 @@ jobs:
      executor: debian-11
      steps:
        - checkout
+       - run: .circleci/bin/halt-if-unchanged .circleci src deps.edn
        - restore_cache: {keys: ['eastwood-deps-v1-{{checksum "deps.edn"}}']}
        - install-sys-deps:
            scenario: lint
@@ -143,6 +151,7 @@ jobs:
      executor: debian-11
      steps:
        - checkout
+       - run: .circleci/bin/halt-if-unchanged .circleci pkg/dist src deps.edn
        - restore_cache:
            keys:
              - pkg-deps-v1-{{checksum "deps.edn"}}-{{checksum "bin/download-pkg-deps"}}
@@ -169,7 +178,9 @@ jobs:
          type: string
      executor: << parameters.executor >>
      steps:
-       - checkout # only so we can access the test diagram YAML file
+       - install-arch-stuff
+       - checkout
+       - run: .circleci/bin/halt-if-unchanged .circleci pkg/dist src deps.edn
        - install-sys-deps:
            scenario: run
        - attach_workspace: {at: ~/workspace} # so we can access the distribution package that was built in build_dist_pkg
@@ -187,6 +198,8 @@ jobs:
    publish_dist_pkg:
      executor: debian-11
      steps:
+       - checkout # only so we can check which paths have changed
+       - run: .circleci/bin/halt-if-unchanged .circleci pkg/dist src deps.edn
        - attach_workspace: {at: ~/workspace}
        - run: |
            [ "$GITHUB_TOKEN" ] || { echo 'GITHUB_TOKEN is not set!' && exit 1; }
@@ -248,6 +261,7 @@ jobs:
        - image: circleci/ruby:2.6
      steps:
        - checkout
+       - run: .circleci/bin/halt-if-unchanged docs
        - run:
            name: Workaround for CCI Ruby cache restore permissions bug
            # See https://github.com/dominicsayers/circleci-2.0-cache-restore/blob/master/README.md

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,33 @@ jobs:
        - save_cache:
           key: test-deps-v2-{{checksum "deps.edn"}}-{{checksum "bin/download-test-deps"}}-<< parameters.executor >>
           paths: [.cpcache, ~/.m2, ~/.gitlibs, ~/Library/Caches/Homebrew]
+       - run: bin/tests
+       - store_test_results: {path: target/test-results}
+
+   test_with_coverage:
+     parameters:
+       executor:
+         type: enum
+         # The Debian executor is our fastest executor right now, and measuring coverage slows down
+         # the tests. So we’ll hard-code this job to run on our Debian executor (for now, at least).
+         # We’re keeping this as a param for now, for consistency. e.g. the param is used in the
+         # deps cache key, and I wouldn’t want to hard-code that part of the key.
+         enum: [debian-11-browsers]
+         default: debian-11-browsers
+     executor: << parameters.executor >>
+     steps:
+       - checkout
+       - install-arch-stuff # Just in case we ever run this job on Arch; in the meantime this is a fast no-op.
+       - run: .circleci/bin/halt-if-unchanged .circleci src test deps.edn
+       - restore_cache:
+           keys:
+             - test-deps-v2-{{checksum "deps.edn"}}-{{checksum "bin/download-test-deps"}}-<< parameters.executor >>
+       - install-sys-deps:
+           scenario: test
+       - run: bin/download-test-deps
+       - save_cache:
+          key: test-deps-v2-{{checksum "deps.edn"}}-{{checksum "bin/download-test-deps"}}-<< parameters.executor >>
+          paths: [.cpcache, ~/.m2, ~/.gitlibs, ~/Library/Caches/Homebrew]
        - run: bin/tests-with-coverage
        - store_test_results: {path: target/test-results}
        - store_artifacts: {path: target/coverage}
@@ -298,8 +325,8 @@ workflows:
       - test:
           name: test_arch
           executor: arch
-      - test:
-          name: test_debian
+      - test_with_coverage:
+          name: test_with_coverage_debian
           executor: debian-11-browsers
       - test:
           name: test_mac_mojave
@@ -323,8 +350,8 @@ workflows:
       - publish_dist_pkg:
           requires:
             - test_arch
-            - test_debian
             - test_mac_mojave
+            - test_with_coverage_debian
             - test_dist_pkg_arch_11
             - test_dist_pkg_deb_11
             - test_dist_pkg_deb_8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,27 @@ jobs:
           # want the job to fail; this step is optional.
           command: bash <(curl -s https://codecov.io/bash) -y .circleci/codecov.yml || echo Codecov upload failed
 
+   test_shutdown_hooks:
+     parameters:
+       executor:
+         type: string
+     executor: << parameters.executor >>
+     steps:
+       - checkout
+       - install-arch-stuff
+       - restore_cache:
+           keys:
+             - test-deps-v2-{{checksum "deps.edn"}}-{{checksum "bin/download-test-deps"}}-<< parameters.executor >>
+       - install-sys-deps: {scenario: test}
+       - run: bin/download-test-deps
+       - save_cache:
+          key: test-deps-v2-{{checksum "deps.edn"}}-{{checksum "bin/download-test-deps"}}-<< parameters.executor >>
+          paths: [.cpcache, ~/.m2, ~/.gitlibs, ~/Library/Caches/Homebrew]
+       # I did a quick Web search to see if there’s a quick, simple, easy, straightforward, reliable way to
+       # have bash run all the scripts in a directory, and of course there is not. Nothing is ever
+       # straightforward with bash.
+       - run: test/scripts/shutdown-hooks
+
    lint_cljfmt:
      executor: debian-11
      steps:
@@ -331,6 +352,9 @@ workflows:
       - test:
           name: test_mac_mojave
           executor: macos-mojave
+      - test_shutdown_hooks:
+          name: test_shutdown_hooks_debian
+          executor: debian-11-browsers
       - test_dist_pkg:
           requires: [build_dist_pkg]
           name: test_dist_pkg_deb_11
@@ -352,6 +376,7 @@ workflows:
             - test_arch
             - test_mac_mojave
             - test_with_coverage_debian
+            - test_shutdown_hooks_debian
             - test_dist_pkg_arch_11
             - test_dist_pkg_deb_11
             - test_dist_pkg_deb_8

--- a/bin/tests
+++ b/bin/tests
@@ -13,8 +13,3 @@ set -eux
 # includes the :test/coverage profile, so that a single script can download the
 # deps for both this script and ./tests-with-coverage
 clojure -J-Xmx2g -A:test:test/run -R:test/coverage
-
-# I did a quick Web search to see if there’s a quick, simple, easy, straightforward, reliable way to
-# have bash run all the scripts in a directory, and of course there is not. Nothing is ever
-# straightforward with bash.
-test/scripts/shutdown-hooks

--- a/bin/tests-with-coverage
+++ b/bin/tests-with-coverage
@@ -7,8 +7,3 @@ set -eux
 # defaults to setting the max heap to ¼ of the total RAM, and CI containers frequently have
 # <= 4GB RAM.)
 clojure -J-Xmx2g -A:test:test/coverage
-
-# I did a quick Web search to see if there’s a quick, simple, easy, straightforward, reliable way to
-# have bash run all the scripts in a directory, and of course there is not. Nothing is ever
-# straightforward with bash.
-test/scripts/shutdown-hooks

--- a/test/scripts/shutdown-hooks
+++ b/test/scripts/shutdown-hooks
@@ -10,7 +10,14 @@ set -eu -o pipefail
 # Clean up the rendered diagram, if it *is* rendered
 trap 'rm -f test/data/structurizr/express/diagram_valid_formatted.png' EXIT
 
-if ! output=$(clojure -A:main --render test/data/structurizr/express/diagram_valid_formatted.yaml); then
+# We’re including the dependencies of test/coverage here, even though we’re not
+# actually measuring coverage in this script, because we want the computed set
+# of deps to be exactly the same as that computed by ./download-test-deps, which
+# includes the :test/coverage profile, so that a single script can download the
+# deps for both this script and ./tests-with-coverage and therefore the same CI cache can be used
+# for all tests.
+
+if ! output=$(clojure -A:test:test/coverage:main --render test/data/structurizr/express/diagram_valid_formatted.yaml); then
   echo "TEST FAILURE: program returned exit code $? with this output:"
   echo "$output"
   exit 1


### PR DESCRIPTION
## Notes for Reviewers

* I recommend reviewing each commit individually.
* Thank you!

## Notes on Commits

### 7ac35ce : Halt CI jobs when no relevant files have changed

I stumbled across [a blog post](https://fant.io/p/circleci-early-exit/) containing a shell script for this purpose, and it looked like a quick, easy, and straightforward way to accomplish this. So I thought I’d give it a try.

This should speed up our CircleCI workflows + pipelines. The early results look good:

Branch | Lint workflow | Test workflow
---- | ---- | -----
[master](https://app.circleci.com/github/FundingCircle/fc4-framework/pipelines?branch=master) | 51s | 9m 14s
[more-faster-ci](https://app.circleci.com/github/FundingCircle/fc4-framework/pipelines?branch=more-faster-ci) | **40s** | **1m 56s**

(I recorded those times when this branch contained only this single commit.)

----

Closes #78