### PR TITLE
Attempt to fix Codecov

### DIFF
--- a/.circleci/codecov.yml
+++ b/.circleci/codecov.yml
@@ -3,6 +3,8 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 1 # up to 1% drop should pass
-        base: auto
-    patch: no
+        threshold: 1%
+    # I have trouble making sense of the patch reports.
+    patch: off
+# Too much noise; interferes with peer review/discussion. The GitHub “status checks” are sufficient.
+comment: false


### PR DESCRIPTION
I’m still having trouble with Codecov seemingly ignoring this config file. I did some research and these changes *might* help. They aren’t helping with the GitHub “status checks” on *this* commit while in a “feature branch” — but it’s possible that Codecov really only uses the config file that’s in the default branch? I don’t know, I’m baffled and aggravated with Codecov. In a different branch I’m trying out some other services like Coveralls and Code Climate.