### PR TITLE
Fix: CI job publish_dist_pkg never runs on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -247,7 +247,12 @@ jobs:
      executor: debian-11
      steps:
        - checkout # only so we can check which paths have changed
-       - run: .circleci/bin/halt-if-unchanged .circleci pkg/dist src deps.edn
+       - run:
+           name: Halt this job if the code hasn’t changed, if branch is *not* master
+           command: |
+             if [[ $CIRCLE_BRANCH != "master" ]]; then
+               .circleci/bin/halt-if-unchanged .circleci pkg/dist src deps.edn
+             fi
        - attach_workspace: {at: ~/workspace}
        - run: |
            [ "$GITHUB_TOKEN" ] || { echo 'GITHUB_TOKEN is not set!' && exit 1; }


### PR DESCRIPTION
We recently merged #262, which included 7ac35cee3: *Halt CI jobs when no
relevant files have changed.* Which has been working well, except I
noticed that the CircleCI workflows on master, after the PR was merged,
were way too fast.

I thought it over, and I realized that the script halt-if-unchanged will
probably always find no changes when it runs on master — in other words,
on master, it only produces false negatives. I think. It’s a hunch, at
least.

I looked over the source of the script, and I don’t *quite* understand
the script well enough to confirm my hunch. That said, it does seem to
be what’s happening, so I think it’s worth making a small change to
ensure that it doesn’t happen.

I hope this change is fairly self-explanatory, but basically, after
this, any time this job runs on master, it will simply skip the call to
half-if-unchanged.

That means that master builds may take a little longer than strictly
necessary, but I think that’s OK. I like sticking with the behavior
we’ve had in-place for a while now that every time a PR is merged to
master, a corresponding distribution package is created, a release is
created, and the package is attached to the release. That sort of
consistency is useful.