### PR TITLE
Fix: CI job publish_dist_pkg fails on master

### DIFF
--- a/.circleci/bin/halt-if-unchanged
+++ b/.circleci/bin/halt-if-unchanged
@@ -13,6 +13,11 @@ set -eu
 # * https://gist.github.com/naesheim/18d0c0a58ee61f4674353a2f4cf71475
 # * https://discuss.circleci.com/t/ability-to-return-successfully-from-a-job-before-completing-all-the-next-steps/12969/4
 
+# 0. Exit on master, because we never skip any steps on master.
+if [[ $CIRCLE_BRANCH == 'master' ]]; then
+  exit 0
+fi
+
 # 1. Get all the arguments of the script
 # https://unix.stackexchange.com/a/197794
 PATHS_TO_SEARCH=("$@")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,7 @@ commands:
       - run:
           name: Install system dependencies
           command: .circleci/bin/install-sys-deps/$OS-<<parameters.scenario>>
+
   install-arch-stuff:
     description: |
       Install stuff needed specifically for Arch Linux very early on: git so we can run
@@ -61,6 +62,18 @@ commands:
             if command -v pacman >> /dev/null; then
               pacman --refresh --sync --needed --noconfirm --noprogressbar git tar
             fi
+
+  dist-pkg-proceed-check:
+    description: |
+      Halts a job if the code hasn’t changed, if branch is *not* master. We always want to run these
+      jobs on master because we’ve long had a practice of always creating a distribution package and
+      release for every change (merge) to master, and I want to retain this.
+    steps:
+      - run:
+          name: Check whether to proceed on this branch with these changes; if not, halt
+          command: |
+             [[ "$CIRCLE_BRANCH" == 'master' ]] || \
+               .circleci/bin/halt-if-unchanged .circleci pkg/dist src deps.edn
 
 jobs:
    test:
@@ -199,7 +212,7 @@ jobs:
      executor: debian-11
      steps:
        - checkout
-       - run: .circleci/bin/halt-if-unchanged .circleci pkg/dist src deps.edn
+       - dist-pkg-proceed-check
        - restore_cache:
            keys:
              - pkg-deps-v1-{{checksum "deps.edn"}}-{{checksum "bin/download-pkg-deps"}}
@@ -228,6 +241,7 @@ jobs:
      steps:
        - install-arch-stuff
        - checkout
+       - dist-pkg-proceed-check
        - run: .circleci/bin/halt-if-unchanged .circleci pkg/dist src deps.edn
        - install-sys-deps:
            scenario: run
@@ -247,12 +261,7 @@ jobs:
      executor: debian-11
      steps:
        - checkout # only so we can check which paths have changed
-       - run:
-           name: Halt this job if the code hasn’t changed, if branch is *not* master
-           command: |
-             if [[ $CIRCLE_BRANCH != "master" ]]; then
-               .circleci/bin/halt-if-unchanged .circleci pkg/dist src deps.edn
-             fi
+       - dist-pkg-proceed-check
        - attach_workspace: {at: ~/workspace}
        - run: |
            [ "$GITHUB_TOKEN" ] || { echo 'GITHUB_TOKEN is not set!' && exit 1; }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,6 @@ commands:
       - run:
           name: Install system dependencies
           command: .circleci/bin/install-sys-deps/$OS-<<parameters.scenario>>
-
   install-arch-stuff:
     description: |
       Install stuff needed specifically for Arch Linux very early on: git so we can run
@@ -62,18 +61,6 @@ commands:
             if command -v pacman >> /dev/null; then
               pacman --refresh --sync --needed --noconfirm --noprogressbar git tar
             fi
-
-  dist-pkg-proceed-check:
-    description: |
-      Halts a job if the code hasn’t changed, if branch is *not* master. We always want to run these
-      jobs on master because we’ve long had a practice of always creating a distribution package and
-      release for every change (merge) to master, and I want to retain this.
-    steps:
-      - run:
-          name: Check whether to proceed on this branch with these changes; if not, halt
-          command: |
-             [[ "$CIRCLE_BRANCH" == 'master' ]] || \
-               .circleci/bin/halt-if-unchanged .circleci pkg/dist src deps.edn
 
 jobs:
    test:
@@ -212,7 +199,7 @@ jobs:
      executor: debian-11
      steps:
        - checkout
-       - dist-pkg-proceed-check
+       - run: .circleci/bin/halt-if-unchanged .circleci pkg/dist src deps.edn
        - restore_cache:
            keys:
              - pkg-deps-v1-{{checksum "deps.edn"}}-{{checksum "bin/download-pkg-deps"}}
@@ -241,7 +228,6 @@ jobs:
      steps:
        - install-arch-stuff
        - checkout
-       - dist-pkg-proceed-check
        - run: .circleci/bin/halt-if-unchanged .circleci pkg/dist src deps.edn
        - install-sys-deps:
            scenario: run
@@ -261,7 +247,12 @@ jobs:
      executor: debian-11
      steps:
        - checkout # only so we can check which paths have changed
-       - dist-pkg-proceed-check
+       - run:
+           name: Halt this job if the code hasn’t changed, if branch is *not* master
+           command: |
+             if [[ $CIRCLE_BRANCH != "master" ]]; then
+               .circleci/bin/halt-if-unchanged .circleci pkg/dist src deps.edn
+             fi
        - attach_workspace: {at: ~/workspace}
        - run: |
            [ "$GITHUB_TOKEN" ] || { echo 'GITHUB_TOKEN is not set!' && exit 1; }


### PR DESCRIPTION
This is a follow-up to #266 / 99f481bc1b. In that commit I modified the
CI job publish_dist_pkg to always run on master. Unfortunately I
neglected to do the same for its dependencies: build_dist_pkg and
test_dist_pkg. So publish_dist_pkg did indeed run on master after that
PR was merged, but it failed, because the distribution package hadn’t
been created. Doh!