### PR TITLE
Fix long tests

### DIFF
--- a/src/fc4/dsl/model.clj
+++ b/src/fc4/dsl/model.clj
@@ -74,7 +74,7 @@
 (s/def ::m/uses
   (s/map-of ::m/ref
             (s/keys :req [::m/to] :opt [::m/container ::m/protocol])
-            :min-elements 1 :max-gen 2))
+            :min-elements 1 :gen-max 2))
 
 ;; Plural version for (classes of) people... English is bizarre.
 (s/def ::m/use ::m/uses)
@@ -83,7 +83,7 @@
   (s/map-of ::m/ref
             (s/keys :req [::m/for]
                     :opt [::m/because ::m/container ::m/protocol])
-            :min-elements 1 :max-gen 2))
+            :min-elements 1 :gen-max 2))
 
 ;; Property of the `reads-from` and/or `writes-to` relationship maps that provides the documentarian
 ;; a place to describe *what* it is that the reader is reading or that the writer is writing.
@@ -96,13 +96,13 @@
   (s/map-of ::m/ref
             (s/keys :req [::m/what]
                     :opt [::m/because ::m/for ::m/so-that ::m/to ::m/protocol])
-            :min-elements 1 :max-gen 2))
+            :min-elements 1 :gen-max 2))
 
 (s/def ::m/writes-to
   (s/map-of ::m/ref
             (s/keys :req [::m/what]
                     :opt [::m/because ::m/for ::m/so-that ::m/to ::m/protocol])
-            :min-elements 1 :max-gen 2))
+            :min-elements 1 :gen-max 2))
 
 (s/def ::m/all-relationships
   (s/keys :opt [::m/uses ::m/depends-on ::m/reads-from ::m/writes-to]))

--- a/test/fc4/test_runner/runner.clj
+++ b/test/fc4/test_runner/runner.clj
@@ -39,7 +39,10 @@
      ;; https://github.com/weavejester/eftest/#multithreading
      :multithread? :vars
 
-     ;; Our test suite just takes too damn long.
+     ;; We have lots of tests that take too damn long.
+     :test-warn-time 10000
+
+     ;; Of course our test suite takes way too damn long.
      :fail-fast? true}))
 
 (defn run-tests


### PR DESCRIPTION
We recently re-added these specs, and after they merged to master I
noticed that our CI builds had become significantly slower. So I looked
to make sure that all the collection specs had `:max-gen` specified (the
default is 20, which can be too much for some really sophisticated data
structures) and I found that some had `:max-gen` but some had `:gen-max`

🤦‍♂️

‍This reduces the total time of the tests for this namespace from ~169
seconds to ~67 seconds, a difference of ~102 seconds!

Before:

```
user=> (time (do (println "master") (run-tests 'fc4.dsl.model-test)))
master

Testing fc4.dsl.model-test

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.
"Elapsed time: 169037.62099 msecs"
{:test 2, :pass 2, :fail 0, :error 0, :type :summary}
```

After:

```
user=> (require :reload 'fc4.dsl.model)
nil
user=> (time (do (println "fix-long-tests") (run-tests 'fc4.dsl.model-test)))
fix-long-tests

Testing fc4.dsl.model-test

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.
"Elapsed time: 66776.056716 msecs"
{:test 2, :pass 2, :fail 0, :error 0, :type :summary}
```