### PR TITLE
Docs: add missing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # FC4
 
-FC4 is a [_Docs as Code_][docs-as-code] tool that helps software creators and documentarians author
-software architecture diagrams using [the C4 model for visualising software architecture][c4-model].
+FC4 is a [_Docs as Code_][docs-as-code] tool that helps software creators and
+[documentarians][documentarians] author software architecture diagrams using
+[the C4 model for visualising software architecture][c4-model].
 
 For more information and to get started using FC4, see [the website][website].
 
@@ -50,5 +51,6 @@ Distributed under [the BSD 3-Clause License](LICENSE).
 [c4-model]: https://c4model.com/
 [contributing]: docs/contributing.md
 [docs-as-code]: https://www.writethedocs.org/guide/docs-as-code/
+[documentarians]: https://www.writethedocs.org/documentarians/
 [new-issue]: https://github.com/FundingCircle/fc4-framework/issues/new
 [website]: https://fundingcircle.github.io/fc4-framework/

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,8 +56,9 @@ redirect_from:
   <figcaption>Example: a container diagram of FC4 itself.</figcaption>
 </figure>
 
-FC4 is a [_Docs as Code_][docs-as-code] tool that helps software creators and documentarians author
-software architecture diagrams using [the C4 model for visualising software architecture][c4-model].
+FC4 is a [_Docs as Code_][docs-as-code] tool that helps software creators and
+[documentarians][documentarians] author software architecture diagrams using
+[the C4 model for visualising software architecture][c4-model].
 
 <ul id="info">
   <li id="builds">
@@ -117,6 +118,7 @@ Distributed under [the BSD 3-Clause License][license].
 
 [c4-model]: https://c4model.com/
 [docs-as-code]: https://www.writethedocs.org/guide/docs-as-code/
+[documentarians]: https://www.writethedocs.org/documentarians/
 [fc4-blog-post]: https://engineering.fundingcircle.com/blog/2018/09/07/the-fc4-framework/
 [floss]: https://en.wikipedia.org/wiki/Free_and_open-source_software
 [license]: https://github.com/FundingCircle/fc4-framework/blob/master/LICENSE


### PR DESCRIPTION
I happened to notice that this “documentarians” wasn’t a hyperlink, which is not great because it’s not a common term.